### PR TITLE
Enable prettier formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,25 +21,28 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      # Set up Node
-    - name: Use Node 14
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14
-        registry-url: 'https://registry.npmjs.org'
+        # Set up Node
+      - name: Use Node 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: "https://registry.npmjs.org"
 
-      # Run install dependencies
-    - name: Install dependencies
-      run: npm i
+        # Run install dependencies
+      - name: Install dependencies
+        run: npm i
 
-      # Build
-    - name: Build
-      run: npm run prepublish
+      - name: Lint
+        run: npm run lint
 
-    - name: Test
-      run: npm test
+        # Build
+      - name: Build
+        run: npm run prepublish
 
-    - name: Test packaging
-      run: npm run package
+      - name: Test
+        run: npm test
+
+      - name: Test packaging
+        run: npm run package

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+---
+ci:
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  autoupdate_schedule: monthly
+  autofix_commit_msg: |
+    chore: auto fixes from pre-commit.com hooks
+
+    for more information, see https://pre-commit.ci
+minimum_pre_commit_version: 2.9.0 # types_or
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    # keep it before markdownlint and eslint
+    rev: "v3.0.0-alpha.4"
+    hooks:
+      - id: prettier
+        types_or: ["markdown", "json", "ts"]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "files.exclude": {
+    ".nyc_output": true,
+    "coverage": true,
+    "lib": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ It's also possible to opt-in later, by setting the `redhat.telemetry.enabled` us
 
 From File > Preferences > Settings (On macOS: Code > Preferences > Settings), search for telemetry, and check the `Redhat > Telemetry : Enabled` setting. This will enable sending all telemetry events from Red Hat extensions going forward.
 
-
 ## How to disable telemetry reporting?
-If you want to stop sending usage data to Red Hat, you can set the `redhat.telemetry.enabled` user setting to `false`. 
+
+If you want to stop sending usage data to Red Hat, you can set the `redhat.telemetry.enabled` user setting to `false`.
 
 From File > Preferences > Settings (On macOS: Code > Preferences > Settings), search for telemetry, and uncheck the `Redhat > Telemetry : Enabled` setting. This will silence all telemetry events from Red Hat extensions going forward.
 
 Additionally, and starting from version 0.5.0, this module abides by Visual Studio Code's telemetry level: if `telemetry.telemetryLevel` is set to `off`, then no telemetry events will be sent to Red Hat, even if `redhat.telemetry.enabled` is set to `true`. If `telemetry.telemetryLevel` is set to `error` or `crash`, only events containing an `error` or `errors` property will be sent to Red Hat.
 
 # Remote configuration
+
 Starting from version 0.5.0, Red Hat Telemetry can be remotely configured. Once every 12h (or whatever is remotely configured), [telemetry-config.json](src/config/telemetry-config.json) will be downloaded to, depending on your platform:
 
 - **Windows** `%APPDATA%\Code\User\globalStorage\vscode-redhat-telemetry\cache\telemetry-config.json`
@@ -31,34 +32,34 @@ Starting from version 0.5.0, Red Hat Telemetry can be remotely configured. Once 
 
 This allows Red Hat extensions to limit the events to be sent, by including or excluding certain events, by name or containing properties, or by limiting the ratio of users sending data.
 eg.:
+
 - 50% of `redhat.vscode-hypothetical` users only, to report error events, excluding stackoverflows:
 
 ```json
 {
-    "*": {
-        "enabled":"all", // supports "all", "error", "crash", "off"
-        "refresh": "12h",
-        "includes": [
-            {
-                "name" : "*"
-            }
-        ]
-    },
-    "redhat.vscode-hypothetical": {
-        "enabled": "error", 
-        "ratio": "0.5",
-        "excludes": [
-            {
-                "property": "error",
-                "value": "*stackoverflow*"
-            }
-        ]
-    }
+  "*": {
+    "enabled": "all", // supports "all", "error", "crash", "off"
+    "refresh": "12h",
+    "includes": [
+      {
+        "name": "*"
+      }
+    ]
+  },
+  "redhat.vscode-hypothetical": {
+    "enabled": "error",
+    "ratio": "0.5",
+    "excludes": [
+      {
+        "property": "error",
+        "value": "*stackoverflow*"
+      }
+    ]
+  }
 }
 ```
 
 Extension configuration inherits and overrides the `*` configuration.
-
 
 # How to use this library
 
@@ -69,7 +70,9 @@ In order to install [`@redhat-developer/vscode-redhat-telemetry`](https://github
 ```
 npm i @redhat-developer/vscode-redhat-telemetry
 ```
+
 ## Contribute the `redhat.telemetry.enabled` preference
+
 Unless your extension already depends on a telemetry-enabled Red Hat extension, it needs to declare the `redhat.telemetry.enabled` preference in its package.json, like:
 
 ```
@@ -89,7 +92,9 @@ Unless your extension already depends on a telemetry-enabled Red Hat extension, 
     }
 }
 ```
+
 ## [Optional] Add a custom segment key in package.json file
+
 By default, extensions will send their data to https://app.segment.com/redhat-devtools/sources/vscode/. In development mode, the data is sent to https://app.segment.com/redhat-devtools/sources/vs_code_tests/.
 
 - You can specify custom segment keys in your package.json, to connect and push usage data to https://segment.com/
@@ -102,13 +107,14 @@ By default, extensions will send their data to https://app.segment.com/redhat-de
 ## Add the below code to your `extension.ts`
 
 Get a reference to the RedHatService instance from your VS Code extension's `activate` method in `extension.ts`:
+
 ```typescript
 import { getRedHatService, TelemetryService } from "@redhat-developer/vscode-redhat-telemetry";
 
 let telemetryService: TelemetryService = null;
 
 export async function activate(context: ExtensionContext) {
-  const redhatService = await getRedHatService(context);  
+  const redhatService = await getRedHatService(context);
   telemetryService = await redhatService.getTelemetryService();
   telemetryService.sendStartupEvent();
   ...
@@ -126,7 +132,7 @@ if (telemetryService) {
     name: "Test Event",
     type: "track", // optional type (track is the default)
     properties: { // optional custom properties
-      foo: "bar", 
+      foo: "bar",
     }
   };
   telemetryService.send(event);
@@ -134,28 +140,32 @@ if (telemetryService) {
 ```
 
 To access the anonymous Red Hat UUID for the current user:
+
 ```typescript
-const redhatUuid = await (await redhatService.getIdManager()).getRedHatUUID();
+const redhatUuid = await(await redhatService.getIdManager()).getRedHatUUID();
 ```
 
 Once your extension is deactivated, a shutdown event, including the session duration, will automatically be sent on its behalf. However, shutdown event delivery is not guaranteed, in case VS Code is faster to exit than to send those last events.
 
 All event properties are automatically sanitized to anonymize all paths (best effort) and references to the username.
 
-
 ## Publicly document your data collection
 
 Once telemetry is in place, you need to document the extent of the telemetry collection performed by your extension.
-* add a USAGE_DATA.md page to your extension's repository, listing the type of data being collected by your extension.
-* add a `Data and Telemetry` paragraph at the end of your extension's README file:
-> `The ***** extension collects anonymous [usage data](USAGE_DATA.md) and sends it to Red Hat servers to help improve our products and services. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection) to learn more. This extension respects the `redhat.telemetry.enabled` setting which you can learn more about at https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting`
 
-* add a reference to your telemetry documentation page to this repository's own [USAGE_DATA.md](https://github.com/redhat-developer/vscode-redhat-telemetry/blob/HEAD/USAGE_DATA.md#other-extensions).
+- add a USAGE_DATA.md page to your extension's repository, listing the type of data being collected by your extension.
+- add a `Data and Telemetry` paragraph at the end of your extension's README file:
+
+  > `The ***** extension collects anonymous [usage data](USAGE_DATA.md) and sends it to Red Hat servers to help improve our products and services. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection) to learn more. This extension respects the `redhat.telemetry.enabled` setting which you can learn more about at https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting`
+
+- add a reference to your telemetry documentation page to this repository's own [USAGE_DATA.md](https://github.com/redhat-developer/vscode-redhat-telemetry/blob/HEAD/USAGE_DATA.md#other-extensions).
 
 ### Checking telemetry during development
+
 In your `.vscode/launch.json`:
+
 - set the `VSCODE_REDHAT_TELEMETRY_DEBUG` environment variable to `true`, to log telemetry events in the console
-- set the `REDHAT_TELEMETRY_REMOTE_CONFIG_URL` environment variable to the URL of a remote configuration file, if you need to test remote configuration 
+- set the `REDHAT_TELEMETRY_REMOTE_CONFIG_URL` environment variable to the URL of a remote configuration file, if you need to test remote configuration
 
 ```json
 {
@@ -176,21 +186,22 @@ In your `.vscode/launch.json`:
 },
 ```
 
-
 # How to use from a VS Code webview
-From a VS Code webview, since you can not rely on accessing the filesystem, you need to instanciate the `TelemetryService` from a `TelemetryServiceBuilder`, providing browser-specific implementations of services for collecting data. 
+
+From a VS Code webview, since you can not rely on accessing the filesystem, you need to instanciate the `TelemetryService` from a `TelemetryServiceBuilder`, providing browser-specific implementations of services for collecting data.
 
 To get a reference to the TelemetryService instance for your VS Code extension:
+
 ```typescript
 import { TelemetryServiceBuilder, TelemetryService, TelemetrySettings, Environment, IdManager } from "@redhat-developer/vscode-redhat-telemetry";
 ...
-const packageJson: any = ...; // an object defining `{publisher:string, name:string, version:string, segmentWriteKey:string}` 
+const packageJson: any = ...; // an object defining `{publisher:string, name:string, version:string, segmentWriteKey:string}`
 const idManager: IdManager = ...; // a service returning Red Hat anonymous UUID
 const environment: Environment = ...; // an object containing environment specific data (OS, locale...)
 const settings:TelemetrySettings = ...;  // an object checking whether telemetry collection is enabled
 const telemetryService: TelemetryService = new TelemetryServiceBuilder(packageJson)
-                                             .setIdManager(idManager) 
-                                             .setEnvironment(environment) 
+                                             .setIdManager(idManager)
+                                             .setEnvironment(environment)
                                              .setSettings(settings)
 ...
 let event = {
@@ -204,14 +215,19 @@ const REDHAT_UUID = idManager.getRedHatUUID();
 ```
 
 # Build
-In a terminal, execute: 
+
+In a terminal, execute:
+
 ```
 npm i
 ```
+
 to install the dependencies, then:
+
 ```
 npm run prepublish
 ```
+
 to build the library
 
 # Information on data transmission during development

--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -1,41 +1,44 @@
 ## Usage data being collected by Red Hat Extensions
+
 Only anonymous data is being collected by Red Hat extensions using `vscode-redhat-telemetry` facilities. The IP address of telemetry requests is not even stored on Red Hat servers.
 All telemetry events are automatically sanitized to anonymize all paths (best effort) and references to the username.
 
 ### Common data
+
 Telemetry requests may contain:
 
-* a random anonymous user id (UUID v4), that is stored locally on `~/.redhat/anonymousId`
-* the client name (VS Code, VSCodium, Eclipse Che...) and its version
-* the type of client (Desktop vs Web)
-* the name and version of the extension sending the event (eg. `fabric8-analytics.fabric8-analytics-vscode-extension`)
-* whether the extension runs remotely or not (eg. in WSL)
-* the OS name and version (and distribution name, in case of Linux)
-* the user locale (eg. en_US)
-* the user timezone
-* the country id ( as determined by the current timezone)
+- a random anonymous user id (UUID v4), that is stored locally on `~/.redhat/anonymousId`
+- the client name (VS Code, VSCodium, Eclipse Che...) and its version
+- the type of client (Desktop vs Web)
+- the name and version of the extension sending the event (eg. `fabric8-analytics.fabric8-analytics-vscode-extension`)
+- whether the extension runs remotely or not (eg. in WSL)
+- the OS name and version (and distribution name, in case of Linux)
+- the user locale (eg. en_US)
+- the user timezone
+- the country id ( as determined by the current timezone)
 
 Common events are reported:
 
-* when extension is started
-* when extension is shutdown
-    - duration of the session
+- when extension is started
+- when extension is shutdown
+  - duration of the session
 
 ### Other extensions
+
 Red Hat extensions' specific telemetry collection details can be found there:
 
-* [Dependency Analytics](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/blob/master/Telemetry.md)
-* [OpenShift Connector](https://github.com/redhat-developer/vscode-openshift-tools/blob/master/USAGE_DATA.md)
-* [Project Initializer](https://github.com/redhat-developer/vscode-project-initializer/blob/master/USAGE_DATA.md)
-* [Quarkus](https://github.com/redhat-developer/vscode-quarkus/blob/master/USAGE_DATA.md)
-* [Red Hat Authentication](https://github.com/redhat-developer/vscode-redhat-account/blob/main/USAGE_DATA.md)
-* [Red Hat OpenShift Application Services](https://github.com/redhat-developer/vscode-rhoas/blob/main/USAGE_DATA.md)
-* [Remote Server Protocol](https://github.com/redhat-developer/vscode-rsp-ui/blob/master/USAGE_DATA.md)
-* [Tekton Pipelines](https://github.com/redhat-developer/vscode-tekton/blob/master/USAGE_DATA.md)
-* [Tooling for Apache Camel K](https://github.com/camel-tooling/vscode-camelk/blob/main/USAGE_DATA.md)
-* [Language Support for Apache Camel](https://github.com/camel-tooling/camel-lsp-client-vscode/blob/main/USAGE_DATA.md)
-* [Debug Adapter for Apache Camel](https://github.com/camel-tooling/camel-dap-client-vscode/blob/main/USAGE_DATA.md)
-* [Tools for MicroProfile](https://github.com/redhat-developer/vscode-microprofile/blob/master/USAGE_DATA.md)
-* [XML](https://github.com/redhat-developer/vscode-xml/blob/master/USAGE_DATA.md)
-* [YAML](https://github.com/redhat-developer/vscode-yaml/blob/main/USAGE_DATA.md)
-* [Ansible](https://github.com/ansible/vscode-ansible/blob/main/USAGE_DATA.md)
+- [Dependency Analytics](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/blob/master/Telemetry.md)
+- [OpenShift Connector](https://github.com/redhat-developer/vscode-openshift-tools/blob/master/USAGE_DATA.md)
+- [Project Initializer](https://github.com/redhat-developer/vscode-project-initializer/blob/master/USAGE_DATA.md)
+- [Quarkus](https://github.com/redhat-developer/vscode-quarkus/blob/master/USAGE_DATA.md)
+- [Red Hat Authentication](https://github.com/redhat-developer/vscode-redhat-account/blob/main/USAGE_DATA.md)
+- [Red Hat OpenShift Application Services](https://github.com/redhat-developer/vscode-rhoas/blob/main/USAGE_DATA.md)
+- [Remote Server Protocol](https://github.com/redhat-developer/vscode-rsp-ui/blob/master/USAGE_DATA.md)
+- [Tekton Pipelines](https://github.com/redhat-developer/vscode-tekton/blob/master/USAGE_DATA.md)
+- [Tooling for Apache Camel K](https://github.com/camel-tooling/vscode-camelk/blob/main/USAGE_DATA.md)
+- [Language Support for Apache Camel](https://github.com/camel-tooling/camel-lsp-client-vscode/blob/main/USAGE_DATA.md)
+- [Debug Adapter for Apache Camel](https://github.com/camel-tooling/camel-dap-client-vscode/blob/main/USAGE_DATA.md)
+- [Tools for MicroProfile](https://github.com/redhat-developer/vscode-microprofile/blob/master/USAGE_DATA.md)
+- [XML](https://github.com/redhat-developer/vscode-xml/blob/master/USAGE_DATA.md)
+- [YAML](https://github.com/redhat-developer/vscode-yaml/blob/main/USAGE_DATA.md)
+- [Ansible](https://github.com/ansible/vscode-ansible/blob/main/USAGE_DATA.md)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "copy-files": "copyfiles -u 1 src/config/* src/tests/config/* lib/",
     "compile": "tsc -p .",
     "build": "npm run clean && npm run copy-files && npm run compile",
+    "lint": "python3 -m pre_commit run -a",
+    "prepare": "python3 -m pip install --user pre-commit",
     "prepublish": "npm run build",
     "coverage": "nyc -r lcov -e .ts -x \"*.ts\" npm run test",
     "test": "mocha -r ts-node/register --ui tdd \"src/tests/**/*.test.ts\"",

--- a/src/che/cheIdManager.ts
+++ b/src/che/cheIdManager.ts
@@ -1,39 +1,38 @@
-import { extensions } from 'vscode';
-import { IdManager } from '../interfaces/idManager';
-import { UUID } from '../utils/uuid';
+import { extensions } from "vscode";
+import { IdManager } from "../interfaces/idManager";
+import { UUID } from "../utils/uuid";
 
 let userId: string;
 export class CheIdManager implements IdManager {
-    async getRedHatUUID(): Promise<string> {
-        if (!userId) {
-            userId = await this.loadRedHatUUID();
-        }
-        return userId;
+  async getRedHatUUID(): Promise<string> {
+    if (!userId) {
+      userId = await this.loadRedHatUUID();
     }
+    return userId;
+  }
 
-    async loadRedHatUUID(): Promise<string> {
-        try {
-            console.log('Reading user id from @eclipse-che.ext-plugin');
-            const che = extensions.getExtension('@eclipse-che.ext-plugin');
-            if (che) {
-                console.log('Found Che API');
-                // grab user
-                const user = await che.exports.user?.getCurrentUser();
+  async loadRedHatUUID(): Promise<string> {
+    try {
+      console.log("Reading user id from @eclipse-che.ext-plugin");
+      const che = extensions.getExtension("@eclipse-che.ext-plugin");
+      if (che) {
+        console.log("Found Che API");
+        // grab user
+        const user = await che.exports.user?.getCurrentUser();
 
-                if (user.id) {
-                    console.log(`Found Che user id ${user.id}`);
-                    return user.id;
-                }
-                console.log('No Che user id');
-
-            } else {
-                console.log('No @eclipse-che.ext-plugin');
-            }
-        } catch (error) {
-            console.log('Failed to get user id from Che', error);
+        if (user.id) {
+          console.log(`Found Che user id ${user.id}`);
+          return user.id;
         }
-        //fall back to generating a random UUID
-        console.log('fall back to generating a random UUID');
-        return UUID.getRedHatUUID();
+        console.log("No Che user id");
+      } else {
+        console.log("No @eclipse-che.ext-plugin");
+      }
+    } catch (error) {
+      console.log("Failed to get user id from Che", error);
     }
+    //fall back to generating a random UUID
+    console.log("fall back to generating a random UUID");
+    return UUID.getRedHatUUID();
+  }
 }

--- a/src/config/telemetry-config.json
+++ b/src/config/telemetry-config.json
@@ -1,11 +1,11 @@
 {
-    "*": {
-        "enabled":"all",
-        "refresh": "12h",
-        "includes": [
-            {
-                "name" : "*"
-            }
-        ]
-    }
+  "*": {
+    "enabled": "all",
+    "refresh": "12h",
+    "includes": [
+      {
+        "name": "*"
+      }
+    ]
+  }
 }

--- a/src/gitpod/gitpodIdManager.ts
+++ b/src/gitpod/gitpodIdManager.ts
@@ -5,31 +5,30 @@ import { UUID } from "../utils/uuid";
 let userId: string;
 
 export class GitpodIdManager implements IdManager {
-    async getRedHatUUID(): Promise<string> {
-        if (!userId) {
-            userId = this.loadRedHatUUID();
+  async getRedHatUUID(): Promise<string> {
+    if (!userId) {
+      userId = this.loadRedHatUUID();
+    }
+    return userId;
+  }
+
+  loadRedHatUUID(redhatDir?: string): string {
+    try {
+      const email = env.GITPOD_GIT_USER_EMAIL;
+      if (email) {
+        userId = UUID.generateUUID(email);
+        const anonymousIdFile = UUID.getAnonymousIdFile(redhatDir);
+        const existingId = UUID.readFile(anonymousIdFile);
+        if (existingId !== userId) {
+          UUID.writeFile(anonymousIdFile, userId);
         }
         return userId;
+      }
+    } catch (error) {
+      console.log("Failed to get user id from Gitpod", error);
     }
-
-    loadRedHatUUID(redhatDir?: string): string {
-        try {
-            const email = env.GITPOD_GIT_USER_EMAIL;
-            if (email) {
-                userId = UUID.generateUUID(email);
-                const anonymousIdFile = UUID.getAnonymousIdFile(redhatDir);
-                const existingId = UUID.readFile(anonymousIdFile);
-                if (existingId !== userId) {
-                    UUID.writeFile(anonymousIdFile, userId);
-                }
-                return userId;
-            }
-        } catch (error) {
-            console.log('Failed to get user id from Gitpod', error);
-        }
-        //fall back to generating a random UUID
-        console.log('fall back to generating a random UUID');
-        return UUID.getRedHatUUID();
-    }
-
+    //fall back to generating a random UUID
+    console.log("fall back to generating a random UUID");
+    return UUID.getRedHatUUID();
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
-import { getRedHatService} from "./vscode/redhatService";
+import { getRedHatService } from "./vscode/redhatService";
 import { TelemetryEvent, TelemetryService } from "./interfaces/telemetry";
 import { IdManager } from "./interfaces/idManager";
 import { Environment } from "./interfaces/environment";
 import { TelemetryServiceBuilder } from "./services/telemetryServiceBuilder";
 import { TelemetrySettings } from "./interfaces/settings";
 
-export { getRedHatService, TelemetryEvent, TelemetryService, TelemetrySettings, TelemetryServiceBuilder, IdManager, Environment };
+export {
+  getRedHatService,
+  TelemetryEvent,
+  TelemetryService,
+  TelemetrySettings,
+  TelemetryServiceBuilder,
+  IdManager,
+  Environment,
+};

--- a/src/interfaces/cacheService.ts
+++ b/src/interfaces/cacheService.ts
@@ -1,11 +1,11 @@
 /**
- * Cache Service 
+ * Cache Service
  */
- export interface CacheService {
-    /**
-     * Returns the value in cache for the given key.
-     */
-    get(key: string):Promise<string|undefined>;
+export interface CacheService {
+  /**
+   * Returns the value in cache for the given key.
+   */
+  get(key: string): Promise<string | undefined>;
 
-    put(key: string, value: string):Promise<boolean>;
+  put(key: string, value: string): Promise<boolean>;
 }

--- a/src/interfaces/envVar.ts
+++ b/src/interfaces/envVar.ts
@@ -1,6 +1,6 @@
 export interface Dict<T> {
   [key: string]: T | undefined;
 }
-let env = (typeof process !== 'undefined')?process.env : {} as Dict<string>;
+let env = typeof process !== "undefined" ? process.env : ({} as Dict<string>);
 
 export default env;

--- a/src/interfaces/environment.ts
+++ b/src/interfaces/environment.ts
@@ -2,71 +2,71 @@
  * Container object holding environment specific data, used to enrich telemetry events.
  */
 export interface Environment {
-    /**
-     * The extension from which Telemetry events are sent.
-     */
-    extension: Application,
+  /**
+   * The extension from which Telemetry events are sent.
+   */
+  extension: Application;
 
-    /**
-     * The client application from which Telemetry events are sent .
-     */
-    application: Client,
+  /**
+   * The client application from which Telemetry events are sent .
+   */
+  application: Client;
 
-    /**
-     * The platform (or OS) from from which Telemetry events are sent.
-     */
-    platform: Platform,
-    /**
-     * User timezone, eg. 'Europe/Paris'
-     */
-    timezone?: string,
+  /**
+   * The platform (or OS) from from which Telemetry events are sent.
+   */
+  platform: Platform;
+  /**
+   * User timezone, eg. 'Europe/Paris'
+   */
+  timezone?: string;
 
-    /**
-     * The user locale, eg. 'en-US'
-     */
-    locale?: string,
+  /**
+   * The user locale, eg. 'en-US'
+   */
+  locale?: string;
 
-    /**
-     * The user's ISO country code, eg. 'CA' for Canada
-     */
-    country?: string,
+  /**
+   * The user's ISO country code, eg. 'CA' for Canada
+   */
+  country?: string;
 
-    /**
-     * Username (used as basis for stripping PII from data)
-     */
-    username?: string
+  /**
+   * Username (used as basis for stripping PII from data)
+   */
+  username?: string;
 }
 
 /**
  * The client application or extension from which Telemetry events are sent.
  */
 export interface Client extends Application {
-    /**
-     * UI Kind (Web / )
-     */
-    uiKind?: string,
-    /**
-     * Runs remotely (eg. in wsl)?
-     */
-    remote?: boolean
+  /**
+   * UI Kind (Web / )
+   */
+  uiKind?: string;
+  /**
+   * Runs remotely (eg. in wsl)?
+   */
+  remote?: boolean;
 }
 
 export interface Application {
-    /**
-     * Client name
-     */
-    name: string,
-    /**
-     * Client version
-     */
-    version: string
+  /**
+   * Client name
+   */
+  name: string;
+  /**
+   * Client version
+   */
+  version: string;
 }
 
 /**
  * The platform (or OS) from which Telemetry events are sent.
  */
 export interface Platform {
-    name: string,
-    distribution?: string,
-    version?: string
+  name: string;
+  distribution?: string;
+  version?: string;
 }

--- a/src/interfaces/idManager.ts
+++ b/src/interfaces/idManager.ts
@@ -1,9 +1,9 @@
 /**
- * Service providing the Red Hat anonymous user id. 
+ * Service providing the Red Hat anonymous user id.
  */
 export interface IdManager {
-    /**
-     * Returns the Red Hat' anonymous user id.
-     */
-    getRedHatUUID():Promise<string>;
+  /**
+   * Returns the Red Hat' anonymous user id.
+   */
+  getRedHatUUID(): Promise<string>;
 }

--- a/src/interfaces/redhatService.ts
+++ b/src/interfaces/redhatService.ts
@@ -3,13 +3,13 @@ import { IdManager, TelemetryService } from "..";
 /**
  * Umbrella for Red Hat services.
  */
- export interface RedHatService {
-     /**
-      * Returns a Telemetry service
-      */
-     getTelemetryService():Promise<TelemetryService>;
-     /**
-      * Returns the Red Hat Id manager
-      */
-     getIdManager():Promise<IdManager>;
+export interface RedHatService {
+  /**
+   * Returns a Telemetry service
+   */
+  getTelemetryService(): Promise<TelemetryService>;
+  /**
+   * Returns the Red Hat Id manager
+   */
+  getIdManager(): Promise<IdManager>;
 }

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -5,7 +5,7 @@ export interface TelemetrySettings {
   /**
    * Returns `true` if Telemetry is enabled.
    */
-  isTelemetryEnabled() : boolean;
+  isTelemetryEnabled(): boolean;
   /**
    * Returns `true` if Telemetry is configured (enabled or not).
    */

--- a/src/interfaces/telemetry.ts
+++ b/src/interfaces/telemetry.ts
@@ -2,40 +2,40 @@
  * Telemetry Event
  */
 export interface TelemetryEvent {
-    type?: string; // type of telemetry event such as : identify, track, page, etc.
-    name: string;
-    properties?: any;
-    measures?: any;
-    traits?: any;
-    context?: any;
+  type?: string; // type of telemetry event such as : identify, track, page, etc.
+  name: string;
+  properties?: any;
+  measures?: any;
+  traits?: any;
+  context?: any;
 }
 
 /**
  * Service for sending Telemetry events
  */
 export interface TelemetryService {
-    /**
-     * Sends a `startup` Telemetry event
-     */
-    sendStartupEvent(): Promise<void>;
-    
-    /**
-     * Sends the Telemetry event
-     */
-    send(event: TelemetryEvent): Promise<void>;
-    
-    /**
-     * Sends a `shutdown` Telemetry event
-     */
-    sendShutdownEvent(): Promise<void>;
+  /**
+   * Sends a `startup` Telemetry event
+   */
+  sendStartupEvent(): Promise<void>;
 
-    /**
-     * Flushes the service's Telemetry events queue
-     */
-    flushQueue(): Promise<void>;
+  /**
+   * Sends the Telemetry event
+   */
+  send(event: TelemetryEvent): Promise<void>;
 
-    /**
-     * Dispose this service
-     */
-    dispose(): Promise<void>;
+  /**
+   * Sends a `shutdown` Telemetry event
+   */
+  sendShutdownEvent(): Promise<void>;
+
+  /**
+   * Flushes the service's Telemetry events queue
+   */
+  flushQueue(): Promise<void>;
+
+  /**
+   * Dispose this service
+   */
+  dispose(): Promise<void>;
 }

--- a/src/node/platform.ts
+++ b/src/node/platform.ts
@@ -1,91 +1,90 @@
-import os from 'os';
-import osLocale from 'os-locale';
-import getos from 'getos';
-import { LinuxOs } from 'getos';
-import { Environment } from '..';
-import { env as vscodeEnv , UIKind, version} from 'vscode';
-import { promisify } from 'util';
+import os from "os";
+import osLocale from "os-locale";
+import getos from "getos";
+import { LinuxOs } from "getos";
+import { Environment } from "..";
+import { env as vscodeEnv, UIKind, version } from "vscode";
+import { promisify } from "util";
 
-import { getCountry } from '../utils/geolocation';
-import env from '../interfaces/envVar';
+import { getCountry } from "../utils/geolocation";
+import env from "../interfaces/envVar";
 
 export const PLATFORM = getPlatform();
 export const DISTRO = getDistribution();
 export const PLATFORM_VERSION = os.release();
 export const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
-export const LOCALE = osLocale.sync().replace('_', '-');
+export const LOCALE = osLocale.sync().replace("_", "-");
 export const COUNTRY = getCountry(TIMEZONE);
 export const UI_KIND = getUIKind();
 export const USERNAME = getUsername();
 
-
 function getPlatform(): string {
-    const platform: string = os.platform();
-    if (platform.startsWith('win')) {
-        return 'Windows';
-    }
-    if (platform.startsWith('darwin')) {
-        return 'Mac';
-    }
-    return platform.charAt(0).toUpperCase() + platform.slice(1);
+  const platform: string = os.platform();
+  if (platform.startsWith("win")) {
+    return "Windows";
+  }
+  if (platform.startsWith("darwin")) {
+    return "Mac";
+  }
+  return platform.charAt(0).toUpperCase() + platform.slice(1);
 }
-async function getDistribution(): Promise<string|undefined> {
-    if (os.platform() === 'linux') {
-      const platform = await promisify(getos)() as LinuxOs;
-      return platform.dist;
-    }
-    return undefined;
+async function getDistribution(): Promise<string | undefined> {
+  if (os.platform() === "linux") {
+    const platform = (await promisify(getos)()) as LinuxOs;
+    return platform.dist;
+  }
+  return undefined;
 }
 
-export async function getEnvironment(extensionId: string, extensionVersion:string): Promise<Environment> {
-    return {
-        extension: {
-            name:extensionId,
-            version:extensionVersion,
-        },
-        application: {
-            name: vscodeEnv.appName,
-            version: version,
-            uiKind: UI_KIND,
-            remote: vscodeEnv.remoteName !== undefined
-        },
-        platform:{
-            name:PLATFORM,
-            version:PLATFORM_VERSION,
-            distribution: await DISTRO
-        },
-        timezone:TIMEZONE,
-        locale:LOCALE,
-        country: COUNTRY,
-        username: USERNAME
-    };
+export async function getEnvironment(
+  extensionId: string,
+  extensionVersion: string,
+): Promise<Environment> {
+  return {
+    extension: {
+      name: extensionId,
+      version: extensionVersion,
+    },
+    application: {
+      name: vscodeEnv.appName,
+      version: version,
+      uiKind: UI_KIND,
+      remote: vscodeEnv.remoteName !== undefined,
+    },
+    platform: {
+      name: PLATFORM,
+      version: PLATFORM_VERSION,
+      distribution: await DISTRO,
+    },
+    timezone: TIMEZONE,
+    locale: LOCALE,
+    country: COUNTRY,
+    username: USERNAME,
+  };
 }
-function getUIKind():string {
-    switch (vscodeEnv.uiKind) {
-        case UIKind.Desktop:
-            return 'Desktop';
-        case UIKind.Web:
-            return 'Web';
-        default:
-            return 'Unknown';
-    }
+function getUIKind(): string {
+  switch (vscodeEnv.uiKind) {
+    case UIKind.Desktop:
+      return "Desktop";
+    case UIKind.Web:
+      return "Web";
+    default:
+      return "Unknown";
+  }
 }
 
 function getUsername(): string | undefined {
-
-    let username = (
-        env.SUDO_USER ||
-        env.C9_USER /* Cloud9 */ ||
-        env.LOGNAME ||
-        env.USER ||
-        env.LNAME ||
-        env.USERNAME
-    );
-    if (!username) {
-        try {
-            username = os.userInfo().username;
-        } catch (_) {}
-    }
-    return username;
+  let username =
+    env.SUDO_USER ||
+    env.C9_USER /* Cloud9 */ ||
+    env.LOGNAME ||
+    env.USER ||
+    env.LNAME ||
+    env.USERNAME;
+  if (!username) {
+    try {
+      username = os.userInfo().username;
+    } catch (_) {}
+  }
+  return username;
 }
-

--- a/src/services/AnalyticsEvent.ts
+++ b/src/services/AnalyticsEvent.ts
@@ -1,10 +1,10 @@
 import { TelemetryEvent } from "../interfaces/telemetry";
 
 export interface AnalyticsEvent {
-    userId: string;
-    event: string;
-    properties?: any;
-    measures?: any;
-    traits?: any;
-    context?: any;
+  userId: string;
+  event: string;
+  properties?: any;
+  measures?: any;
+  traits?: any;
+  context?: any;
 }

--- a/src/services/FileSystemStorageService.ts
+++ b/src/services/FileSystemStorageService.ts
@@ -1,44 +1,44 @@
-import * as fs from 'fs';
+import * as fs from "fs";
 import path from "path";
 
-export class FileSystemStorageService { //implements StorageService {
-    
-    private storagePath: string;
+export class FileSystemStorageService {
+  //implements StorageService {
 
-    constructor(storagePath: string) {
-        this.storagePath = storagePath;
-        if (!fs.existsSync(storagePath)) {
-            fs.mkdirSync(storagePath, { recursive: true });
+  private storagePath: string;
+
+  constructor(storagePath: string) {
+    this.storagePath = storagePath;
+    if (!fs.existsSync(storagePath)) {
+      fs.mkdirSync(storagePath, { recursive: true });
+    }
+  }
+
+  public readFromFile(fileName: string): Promise<string | undefined> {
+    const filePath = path.resolve(this.storagePath, fileName);
+    return new Promise((resolve, reject) => {
+      if (!fs.existsSync(filePath)) {
+        resolve(undefined);
+        return;
+      }
+      fs.readFile(filePath, "utf8", (err, data) => {
+        if (err) {
+          resolve(undefined);
+          return;
         }
-    }
+        resolve(data);
+      });
+    });
+  }
 
-    public readFromFile(fileName: string): Promise<string | undefined> {
-        const filePath = path.resolve(this.storagePath, fileName);
-        return new Promise((resolve, reject) => {
-            if (!fs.existsSync(filePath)) {
-                resolve(undefined);
-                return;
-            }
-            fs.readFile(filePath, 'utf8', (err, data) => {
-                if (err) {
-                    resolve(undefined);
-                    return;
-                }
-                resolve(data);
-            });
-        });
-    }
-
-    public writeToFile(filename: string, content: string): Promise<boolean> {
-        const filePath = path.resolve(this.storagePath, filename);
-        return new Promise((resolve, _reject) => {
-            fs.writeFile(filePath, content, (err) => {
-                if (err) {
-                    resolve(false);
-                }
-                resolve(true);
-            });
-        });
-    }
-
+  public writeToFile(filename: string, content: string): Promise<boolean> {
+    const filePath = path.resolve(this.storagePath, filename);
+    return new Promise((resolve, _reject) => {
+      fs.writeFile(filePath, content, (err) => {
+        if (err) {
+          resolve(false);
+        }
+        resolve(true);
+      });
+    });
+  }
 }

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -4,121 +4,124 @@ import { numValue } from "../utils/hashcode";
 import { AnalyticsEvent } from "./AnalyticsEvent";
 
 interface EventNamePattern {
-    name: string;
+  name: string;
 }
 
 interface PropertyPattern {
-    property: string;
-    value: string;
+  property: string;
+  value: string;
 }
 
 type EventPattern = EventNamePattern | PropertyPattern;
 
 export class Configuration {
+  json: any;
 
-    json: any;
+  constructor(json: any) {
+    this.json = json;
+  }
 
-    constructor(json: any) {
-        this.json = json;
+  public isEnabled(): boolean {
+    return this.json?.enabled === undefined || "off" !== this.json?.enabled;
+  }
+
+  public canSend(event: AnalyticsEvent): boolean {
+    if (!this.isEnabled()) {
+      return false;
+    }
+    if (["error", "crash"].includes(this.json?.enabled) && !isError(event)) {
+      return false;
     }
 
-    public isEnabled(): boolean {
-        return (this.json?.enabled) === undefined || "off" !== (this.json?.enabled)
+    const ratio = this.getRatio();
+    if (ratio < 1.0) {
+      const userNumValue = numValue(event.userId);
+      if (userNumValue > ratio) {
+        return false;
+      }
     }
 
-    public canSend(event: AnalyticsEvent): boolean {
-        if (!this.isEnabled()) {
-            return false;
-        }
-        if ( ["error","crash"].includes(this.json?.enabled) && !isError(event)) {
-            return false;
-        }
+    const isIncluded = this.isIncluded(event) && !this.isExcluded(event);
+    return isIncluded;
+  }
 
-        const ratio = this.getRatio();
-        if (ratio < 1.0) {
-            const userNumValue = numValue(event.userId);
-            if (userNumValue > ratio) {
-                return false;
-            }
-        }
-
-        const isIncluded = this.isIncluded(event) && !this.isExcluded(event);
-        return isIncluded;
+  isIncluded(event: AnalyticsEvent): boolean {
+    const includes = this.getIncludePatterns();
+    if (includes.length) {
+      return isEventMatching(event, includes);
     }
+    return true;
+  }
 
-    isIncluded(event: AnalyticsEvent): boolean {
-        const includes = this.getIncludePatterns();
-        if (includes.length) {
-           return isEventMatching(event, includes);
+  isExcluded(event: AnalyticsEvent): boolean {
+    const excludes = this.getExcludePatterns();
+    if (excludes.length) {
+      return isEventMatching(event, excludes);
+    }
+    return false;
+  }
+
+  getIncludePatterns(): EventPattern[] {
+    if (this.json?.includes) {
+      return this.json.includes as EventPattern[];
+    }
+    return [];
+  }
+
+  getExcludePatterns(): EventPattern[] {
+    if (this.json.excludes) {
+      return this.json.excludes as EventPattern[];
+    }
+    return [];
+  }
+
+  getRatio(): number {
+    if (this.json.ratio) {
+      try {
+        return parseFloat(this.json.ratio);
+      } catch (e) {
+        // ignore
+      }
+    }
+    return 1.0;
+  }
+}
+
+function isEventMatching(
+  event: AnalyticsEvent,
+  patterns: EventPattern[],
+): boolean {
+  if (!patterns || !patterns.length) {
+    return false;
+  }
+  const match = patterns.find((evtPtn) => {
+    if (isPropertyPattern(evtPtn)) {
+      const props = event.properties;
+      if (props) {
+        const value = props[evtPtn.property];
+        const propertyPattern = evtPtn.value;
+        if (value && minimatch(value, propertyPattern)) {
+          return true;
         }
+      }
+    } else {
+      const eventNamePattern = evtPtn.name;
+      if (
+        eventNamePattern &&
+        event.event &&
+        minimatch(event.event, eventNamePattern)
+      ) {
         return true;
+      }
     }
-
-    isExcluded(event: AnalyticsEvent): boolean {
-        const excludes = this.getExcludePatterns();
-        if (excludes.length) {
-           return isEventMatching(event, excludes);
-        }
-        return false;
-    }
-
-    getIncludePatterns(): EventPattern[] {
-        if (this.json?.includes) {
-            return this.json.includes as EventPattern[];
-        }
-        return [];
-    }
-
-    getExcludePatterns(): EventPattern[] {
-        if (this.json.excludes) {
-            return this.json.excludes as EventPattern[];
-        }
-        return [];
-    }
-
-    getRatio(): number {
-        if (this.json.ratio) {
-            try {
-                return parseFloat(this.json.ratio);
-
-            } catch(e) {
-                // ignore
-            }
-        }
-        return 1.0;
-    }
-
+    return false;
+  });
+  return !!match;
 }
-
-function isEventMatching(event: AnalyticsEvent, patterns:EventPattern[]):boolean {
-    if (!patterns || !patterns.length) {
-        return false;
-    }
-    const match = patterns.find(evtPtn => {
-        if (isPropertyPattern(evtPtn)) {
-            const props = event.properties;
-            if (props) {
-                const value = props[evtPtn.property];
-                const propertyPattern = evtPtn.value;
-                if (value && minimatch(value, propertyPattern)) {
-                    return true;
-                }
-            }
-        } else {
-            const eventNamePattern = evtPtn.name;
-            if (eventNamePattern && event.event && minimatch(event.event, eventNamePattern)) {
-                return true;
-            }
-        }
-        return false;
-    });
-    return !!match;
-}
-
 
 function isPropertyPattern(event: EventPattern): event is PropertyPattern {
-    if ((event as PropertyPattern).property) {
-        return true
-    }
-    return false
+  if ((event as PropertyPattern).property) {
+    return true;
+  }
+  return false;
 }

--- a/src/services/configurationManager.ts
+++ b/src/services/configurationManager.ts
@@ -1,131 +1,143 @@
 import { Configuration } from "./configuration";
-import axios from 'axios';
+import axios from "axios";
 import { FileSystemStorageService } from "./FileSystemStorageService";
 import env from "../interfaces/envVar";
 
-export const DEFAULT_CONFIG_URL =  'https://raw.githubusercontent.com/redhat-developer/vscode-redhat-telemetry/main/src/config/telemetry-config.json';
+export const DEFAULT_CONFIG_URL =
+  "https://raw.githubusercontent.com/redhat-developer/vscode-redhat-telemetry/main/src/config/telemetry-config.json";
 export const TELEMETRY_CONFIG = "telemetry-config.json";
 
 export class ConfigurationManager {
-    public static REMOTE_CONFIG_KEY = 'REDHAT_TELEMETRY_REMOTE_CONFIG_URL';
-    public static TEST_CONFIG_KEY = 'REDHAT_TELEMETRY_TEST_CONFIG_KEY';
+  public static REMOTE_CONFIG_KEY = "REDHAT_TELEMETRY_REMOTE_CONFIG_URL";
+  public static TEST_CONFIG_KEY = "REDHAT_TELEMETRY_TEST_CONFIG_KEY";
 
-    constructor(private extensionId: string, private storageService: FileSystemStorageService){}
+  constructor(
+    private extensionId: string,
+    private storageService: FileSystemStorageService,
+  ) {}
 
-    private extensionConfig: Promise<Configuration>|undefined;
+  private extensionConfig: Promise<Configuration> | undefined;
 
-    public async refresh(): Promise<void> {
-        const remoteConfig = await this.fetchRemoteConfiguration();
-        if (remoteConfig) {
-            remoteConfig['timestamp'] = new Date().getTime();
-            await this.saveLocalConfiguration(remoteConfig);
-        }
-        return remoteConfig;
+  public async refresh(): Promise<void> {
+    const remoteConfig = await this.fetchRemoteConfiguration();
+    if (remoteConfig) {
+      remoteConfig["timestamp"] = new Date().getTime();
+      await this.saveLocalConfiguration(remoteConfig);
     }
+    return remoteConfig;
+  }
 
-    public async getExtensionConfiguration(): Promise<Configuration> {
-        let extensionConfig = this.extensionConfig;
-        if (extensionConfig) {
-            if (!isStale(await extensionConfig)) {
-                return extensionConfig;
-            }
-            this.extensionConfig = undefined;
-        }
-        console.log("Loading json config for "+this.extensionId);
-        this.extensionConfig = this.loadConfiguration(this.extensionId);
-        return this.extensionConfig;
+  public async getExtensionConfiguration(): Promise<Configuration> {
+    let extensionConfig = this.extensionConfig;
+    if (extensionConfig) {
+      if (!isStale(await extensionConfig)) {
+        return extensionConfig;
+      }
+      this.extensionConfig = undefined;
     }
+    console.log("Loading json config for " + this.extensionId);
+    this.extensionConfig = this.loadConfiguration(this.extensionId);
+    return this.extensionConfig;
+  }
 
-    private async loadConfiguration(extensionId: string): Promise<Configuration> {
-        let localConfig: any;
-        try {
-            localConfig = await this.getLocalConfiguration();
-            if (isStale(localConfig)) {
-                localConfig = await this.refresh();
-            }
-        } catch(e: any) {
-            console.error(`Failed to load local configuration: ${e?.message}`);
-        }
-        let fullConfig:any;
-        if (localConfig) {
-            fullConfig = localConfig;
-        } else {
-            fullConfig = await this.getEmbeddedConfiguration();
-        }
-        const json = getExtensionConfig(fullConfig, extensionId);
-        return new Configuration(json);
+  private async loadConfiguration(extensionId: string): Promise<Configuration> {
+    let localConfig: any;
+    try {
+      localConfig = await this.getLocalConfiguration();
+      if (isStale(localConfig)) {
+        localConfig = await this.refresh();
+      }
+    } catch (e: any) {
+      console.error(`Failed to load local configuration: ${e?.message}`);
     }
-    async saveLocalConfiguration(fullConfig: any): Promise<boolean> {
-        try {
-            return this.storageService.writeToFile(TELEMETRY_CONFIG, JSON.stringify(fullConfig, null, 2));
-        } catch (e) {
-            console.error(`Error saving configuration locally: ${e}`);
-        }
-        return false;
+    let fullConfig: any;
+    if (localConfig) {
+      fullConfig = localConfig;
+    } else {
+      fullConfig = await this.getEmbeddedConfiguration();
     }
+    const json = getExtensionConfig(fullConfig, extensionId);
+    return new Configuration(json);
+  }
+  async saveLocalConfiguration(fullConfig: any): Promise<boolean> {
+    try {
+      return this.storageService.writeToFile(
+        TELEMETRY_CONFIG,
+        JSON.stringify(fullConfig, null, 2),
+      );
+    } catch (e) {
+      console.error(`Error saving configuration locally: ${e}`);
+    }
+    return false;
+  }
 
-    public async fetchRemoteConfiguration(uri?: string): Promise<any> {
-        let telemetryUri = ( uri )? uri: env[ConfigurationManager.REMOTE_CONFIG_KEY];
-        if (!telemetryUri) {
-            telemetryUri = DEFAULT_CONFIG_URL;
-        } 
-        console.log(`Updating vscode-redhat-telemetry configuration from ${telemetryUri}`);
-        const response = await axios.get(telemetryUri);
-        try {
-            return response?.data;
-        } catch (e) {
-            console.error(`Failed to parse:\n`+response?.data+'\n'+e);
-        }
-        return undefined;
+  public async fetchRemoteConfiguration(uri?: string): Promise<any> {
+    let telemetryUri = uri ? uri : env[ConfigurationManager.REMOTE_CONFIG_KEY];
+    if (!telemetryUri) {
+      telemetryUri = DEFAULT_CONFIG_URL;
     }
-
-    public async getLocalConfiguration(): Promise<any|undefined> {
-        const content = await this.storageService.readFromFile(TELEMETRY_CONFIG);
-        if (content) {
-            return JSON.parse(content);
-        }
-        return undefined;
+    console.log(
+      `Updating vscode-redhat-telemetry configuration from ${telemetryUri}`,
+    );
+    const response = await axios.get(telemetryUri);
+    try {
+      return response?.data;
+    } catch (e) {
+      console.error(`Failed to parse:\n` + response?.data + "\n" + e);
     }
+    return undefined;
+  }
 
-    public async getEmbeddedConfiguration(): Promise<any> {
-        const testConfig = env[ConfigurationManager.TEST_CONFIG_KEY];
-        if (testConfig) {
-            return require('../tests/config/telemetry-config.json');// hard-coded to keep webpack happy
-        }
-        return require('../config/telemetry-config.json');
+  public async getLocalConfiguration(): Promise<any | undefined> {
+    const content = await this.storageService.readFromFile(TELEMETRY_CONFIG);
+    if (content) {
+      return JSON.parse(content);
     }
+    return undefined;
+  }
 
+  public async getEmbeddedConfiguration(): Promise<any> {
+    const testConfig = env[ConfigurationManager.TEST_CONFIG_KEY];
+    if (testConfig) {
+      return require("../tests/config/telemetry-config.json"); // hard-coded to keep webpack happy
+    }
+    return require("../config/telemetry-config.json");
+  }
 }
 const refreshPattern = /\d+/g;
 const REFRESH_PERIOD = 6;
 const HOUR_IN_MILLISEC = 60 * 60 * 1000;
 
 function isStale(configOrJson: any): boolean {
-    if (!configOrJson) {
-        return true;
+  if (!configOrJson) {
+    return true;
+  }
+  let config: any;
+  if (configOrJson instanceof Configuration) {
+    config = configOrJson.json;
+  } else {
+    config = configOrJson;
+  }
+  const timestamp = config.timestamp ? config.timestamp : 0;
+  let period = REFRESH_PERIOD;
+  if (config.refresh) {
+    const res = (config.refresh as string).match(refreshPattern);
+    if (res && res.length) {
+      period = parseInt(res[0]);
     }
-    let config: any;
-    if (configOrJson instanceof Configuration) {
-        config = configOrJson.json;
-    } else {
-        config = configOrJson;
-    }
-    const timestamp = config.timestamp? config.timestamp : 0;
-    let period = REFRESH_PERIOD;
-    if (config.refresh) {
-       const res = (config.refresh as string).match(refreshPattern);
-       if (res && res.length) {
-        period = parseInt(res[0]);
-       }
-    }
-    let elapsed = new Date().getTime() - timestamp;
-    return (elapsed > period * HOUR_IN_MILLISEC);
+  }
+  let elapsed = new Date().getTime() - timestamp;
+  return elapsed > period * HOUR_IN_MILLISEC;
 }
 
 function getExtensionConfig(fullConfig: any, extensionId: string) {
-    const extensionConfig = Object.assign({}, fullConfig['*'], fullConfig[extensionId]);
-    if (fullConfig.timestamp) {
-        extensionConfig['timestamp'] = fullConfig.timestamp;
-    }
-    return extensionConfig;
+  const extensionConfig = Object.assign(
+    {},
+    fullConfig["*"],
+    fullConfig[extensionId],
+  );
+  if (fullConfig.timestamp) {
+    extensionConfig["timestamp"] = fullConfig.timestamp;
+  }
+  return extensionConfig;
 }

--- a/src/services/fileSystemCacheService.ts
+++ b/src/services/fileSystemCacheService.ts
@@ -1,29 +1,30 @@
 import { CacheService } from "../interfaces/cacheService";
 import { FileSystemStorageService } from "./FileSystemStorageService";
 
-export class FileSystemCacheService extends FileSystemStorageService implements CacheService {
-    
-    private memCache = new Map<string, string>();
+export class FileSystemCacheService
+  extends FileSystemStorageService
+  implements CacheService
+{
+  private memCache = new Map<string, string>();
 
-    constructor(storagePath: string) {
-        super(storagePath);
+  constructor(storagePath: string) {
+    super(storagePath);
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    if (this.memCache.has(key)) {
+      return Promise.resolve(this.memCache.get(key));
     }
-
-    async get(key: string): Promise<string | undefined> {
-        if (this.memCache.has(key)) {
-            return Promise.resolve(this.memCache.get(key));
-        }
-        const value = await this.readFromFile(`${key}.txt`);
-        if (value) {
-            this.memCache.set(key, value);
-        }
-        return value;
+    const value = await this.readFromFile(`${key}.txt`);
+    if (value) {
+      this.memCache.set(key, value);
     }
+    return value;
+  }
 
-    async put(key: string, value: string): Promise<boolean> {
-        this.memCache.set(key, value);
-        await this.writeToFile(`${key}.txt`, value);
-        return true;
-    }
-
+  async put(key: string, value: string): Promise<boolean> {
+    this.memCache.set(key, value);
+    await this.writeToFile(`${key}.txt`, value);
+    return true;
+  }
 }

--- a/src/services/fileSystemIdManager.ts
+++ b/src/services/fileSystemIdManager.ts
@@ -2,10 +2,10 @@ import { IdManager } from "../interfaces/idManager";
 import { UUID } from "../utils/uuid";
 
 /**
- * Service providing the Red Hat anonymous user id, read/stored from the `~/.redhat/anonymousId` file. 
+ * Service providing the Red Hat anonymous user id, read/stored from the `~/.redhat/anonymousId` file.
  */
 export class FileSystemIdManager implements IdManager {
-    async getRedHatUUID(): Promise<string> {
-        return UUID.getRedHatUUID();
-    }
+  async getRedHatUUID(): Promise<string> {
+    return UUID.getRedHatUUID();
+  }
 }

--- a/src/services/idManagerFactory.ts
+++ b/src/services/idManagerFactory.ts
@@ -1,18 +1,16 @@
-import { IdManager } from '../interfaces/idManager';
-import { CheIdManager } from '../che/cheIdManager';
-import { FileSystemIdManager } from './fileSystemIdManager';
-import { GitpodIdManager } from '../gitpod/gitpodIdManager';
-import env from '../interfaces/envVar';
+import { IdManager } from "../interfaces/idManager";
+import { CheIdManager } from "../che/cheIdManager";
+import { FileSystemIdManager } from "./fileSystemIdManager";
+import { GitpodIdManager } from "../gitpod/gitpodIdManager";
+import env from "../interfaces/envVar";
 
 export namespace IdManagerFactory {
-
-    export function getIdManager(): IdManager {
-        if (env['CHE_WORKSPACE_ID']) {
-            return new CheIdManager();
-        } else if (env['GITPOD_GIT_USER_EMAIL']) {
-            return new GitpodIdManager();
-        }
-        return new FileSystemIdManager();
+  export function getIdManager(): IdManager {
+    if (env["CHE_WORKSPACE_ID"]) {
+      return new CheIdManager();
+    } else if (env["GITPOD_GIT_USER_EMAIL"]) {
+      return new GitpodIdManager();
     }
-
+    return new FileSystemIdManager();
+  }
 }

--- a/src/services/reporter.ts
+++ b/src/services/reporter.ts
@@ -1,48 +1,55 @@
-import Analytics from 'analytics-node';
-import { sha1 } from 'object-hash';
-import { CacheService } from '../interfaces/cacheService';
-import { Logger } from '../utils/logger';
-import { AnalyticsEvent } from './AnalyticsEvent';
+import Analytics from "analytics-node";
+import { sha1 } from "object-hash";
+import { CacheService } from "../interfaces/cacheService";
+import { Logger } from "../utils/logger";
+import { AnalyticsEvent } from "./AnalyticsEvent";
 
 /**
  * Sends Telemetry events to a segment.io backend
  */
 export class Reporter {
+  constructor(
+    private analytics?: Analytics,
+    private cacheService?: CacheService,
+  ) {}
 
-  constructor(private analytics?: Analytics, private cacheService?: CacheService) {
-  }
-
-  public async report(event: AnalyticsEvent, type: string = 'track'): Promise<void> {
+  public async report(
+    event: AnalyticsEvent,
+    type: string = "track",
+  ): Promise<void> {
     if (!this.analytics) {
       return;
     }
     const payloadString = JSON.stringify(event);
     switch (type) {
-      case 'identify':
+      case "identify":
         //Avoid identifying the user several times, until some data has changed.
         const hash = sha1(payloadString);
-        const cached = await this.cacheService?.get('identify');
+        const cached = await this.cacheService?.get("identify");
         if (hash === cached) {
-          Logger.log(`Skipping 'identify' event! Already sent:\n${payloadString}`);
+          Logger.log(
+            `Skipping 'identify' event! Already sent:\n${payloadString}`,
+          );
           return;
         }
         Logger.log(`Sending 'identify' event with\n${payloadString}`);
         this.analytics?.identify(event);
-        this.cacheService?.put('identify', hash);
+        this.cacheService?.put("identify", hash);
         break;
-      case 'track':
+      case "track":
         Logger.log(`Sending 'track' event with\n${payloadString}`);
         this.analytics?.track(event);
         break;
-      case 'page':
+      case "page":
         Logger.log(`Sending 'page' event with\n${payloadString}`);
         this.analytics?.page(event);
         break;
       default:
-        Logger.log(`Skipping unsupported (yet?) '${type}' event with\n${payloadString}`);
+        Logger.log(
+          `Skipping unsupported (yet?) '${type}' event with\n${payloadString}`,
+        );
         break;
     }
-
   }
 
   public async flush(): Promise<void> {

--- a/src/services/telemetryServiceBuilder.ts
+++ b/src/services/telemetryServiceBuilder.ts
@@ -1,96 +1,105 @@
-import { Environment } from '../interfaces/environment';
-import { IdManager } from '../interfaces/idManager';
-import { Reporter } from './reporter';
-import { TelemetryService } from '../interfaces/telemetry';
-import { TelemetryServiceImpl } from './telemetryServiceImpl';
-import { TelemetryEventQueue } from '../utils/telemetryEventQueue';
-import { TelemetrySettings } from '../interfaces/settings';
-import { SegmentInitializer } from '../utils/segmentInitializer';
-import { FileSystemIdManager } from './fileSystemIdManager';
-import { getExtensionId } from '../utils/extensions';
-import { CacheService } from '../interfaces/cacheService';
-import { ConfigurationManager } from './configurationManager';
+import { Environment } from "../interfaces/environment";
+import { IdManager } from "../interfaces/idManager";
+import { Reporter } from "./reporter";
+import { TelemetryService } from "../interfaces/telemetry";
+import { TelemetryServiceImpl } from "./telemetryServiceImpl";
+import { TelemetryEventQueue } from "../utils/telemetryEventQueue";
+import { TelemetrySettings } from "../interfaces/settings";
+import { SegmentInitializer } from "../utils/segmentInitializer";
+import { FileSystemIdManager } from "./fileSystemIdManager";
+import { getExtensionId } from "../utils/extensions";
+import { CacheService } from "../interfaces/cacheService";
+import { ConfigurationManager } from "./configurationManager";
 
 /**
  * `TelemetryService` builder
  */
 export class TelemetryServiceBuilder {
-    private packageJson: any;
-    private settings?: TelemetrySettings;
-    private idManager?: IdManager;
-    private environment?: Environment;
-    private cacheService?: CacheService;
-    private configurationManager?: ConfigurationManager;
-  
-    constructor(packageJson?:any) {
-      this.packageJson = packageJson;
-    }
-  
-    public setPackageJson(packageJson: any): TelemetryServiceBuilder {
-        this.packageJson = packageJson;
-        return this;
-    }
+  private packageJson: any;
+  private settings?: TelemetrySettings;
+  private idManager?: IdManager;
+  private environment?: Environment;
+  private cacheService?: CacheService;
+  private configurationManager?: ConfigurationManager;
 
-    public setSettings(settings: TelemetrySettings): TelemetryServiceBuilder {
-        this.settings = settings;
-        return this;
-    }
+  constructor(packageJson?: any) {
+    this.packageJson = packageJson;
+  }
 
-    public setIdManager(idManager: IdManager): TelemetryServiceBuilder {
-        this.idManager = idManager;
-        return this;
-    }
+  public setPackageJson(packageJson: any): TelemetryServiceBuilder {
+    this.packageJson = packageJson;
+    return this;
+  }
 
-    public setEnvironment(environment: Environment): TelemetryServiceBuilder {
-        this.environment = environment;
-        return this;
-    }
+  public setSettings(settings: TelemetrySettings): TelemetryServiceBuilder {
+    this.settings = settings;
+    return this;
+  }
 
-    public setConfigurationManager(configManager: ConfigurationManager): TelemetryServiceBuilder {
-        this.configurationManager = configManager;
-        return this;
-    }
+  public setIdManager(idManager: IdManager): TelemetryServiceBuilder {
+    this.idManager = idManager;
+    return this;
+  }
 
-    public setCacheService(cacheService: CacheService): TelemetryServiceBuilder {
-        this.cacheService = cacheService;
-        return this;
-    }
+  public setEnvironment(environment: Environment): TelemetryServiceBuilder {
+    this.environment = environment;
+    return this;
+  }
 
-    public async build(): Promise<TelemetryService> {
-        this.validate();
-        const analytics = SegmentInitializer.initialize(this.packageJson);
-        if (!this.idManager) {
-            this.idManager = new FileSystemIdManager();
-        }
-        if (!this.environment) {
-            this.environment = {
-                extension: {
-                    name: getExtensionId(this.packageJson),
-                    version: this.packageJson.version
-                },
-                application: {
-                    name: 'Unknown',
-                    version: '-'
-                },
-                platform:{
-                    name:'Unknown',
-                    version:'-'
-                }
-            };
-        }
-        const reporter = new Reporter(analytics, this.cacheService);
-        const queue = this.settings!.isTelemetryConfigured()
-          ? undefined
-          : new TelemetryEventQueue();
-        return new TelemetryServiceImpl(reporter, queue, this.settings!, this.idManager, this.environment!, this.configurationManager);
-    }
+  public setConfigurationManager(
+    configManager: ConfigurationManager,
+  ): TelemetryServiceBuilder {
+    this.configurationManager = configManager;
+    return this;
+  }
 
-    private validate() {
-        if (!this.packageJson) {
-            throw new Error('packageJson is not set');
-        }
-        if (!this.environment) {
-            throw new Error('Environment is not set');
-        }
+  public setCacheService(cacheService: CacheService): TelemetryServiceBuilder {
+    this.cacheService = cacheService;
+    return this;
+  }
+
+  public async build(): Promise<TelemetryService> {
+    this.validate();
+    const analytics = SegmentInitializer.initialize(this.packageJson);
+    if (!this.idManager) {
+      this.idManager = new FileSystemIdManager();
     }
+    if (!this.environment) {
+      this.environment = {
+        extension: {
+          name: getExtensionId(this.packageJson),
+          version: this.packageJson.version,
+        },
+        application: {
+          name: "Unknown",
+          version: "-",
+        },
+        platform: {
+          name: "Unknown",
+          version: "-",
+        },
+      };
+    }
+    const reporter = new Reporter(analytics, this.cacheService);
+    const queue = this.settings!.isTelemetryConfigured()
+      ? undefined
+      : new TelemetryEventQueue();
+    return new TelemetryServiceImpl(
+      reporter,
+      queue,
+      this.settings!,
+      this.idManager,
+      this.environment!,
+      this.configurationManager,
+    );
+  }
+
+  private validate() {
+    if (!this.packageJson) {
+      throw new Error("packageJson is not set");
+    }
+    if (!this.environment) {
+      throw new Error("Environment is not set");
+    }
+  }
 }

--- a/src/services/telemetryServiceImpl.ts
+++ b/src/services/telemetryServiceImpl.ts
@@ -1,13 +1,13 @@
-import { Reporter } from './reporter';
-import { Logger } from '../utils/logger';
-import { TelemetrySettings } from '../interfaces/settings';
-import { TelemetryEventQueue } from '../utils/telemetryEventQueue';
-import { TelemetryService, TelemetryEvent } from '../interfaces/telemetry';
-import { CacheService } from '../interfaces/cacheService';
-import { ConfigurationManager } from './configurationManager';
-import { IdManager } from '../interfaces/idManager';
-import { Environment } from '../interfaces/environment';
-import { enhance, isError } from '../utils/events';
+import { Reporter } from "./reporter";
+import { Logger } from "../utils/logger";
+import { TelemetrySettings } from "../interfaces/settings";
+import { TelemetryEventQueue } from "../utils/telemetryEventQueue";
+import { TelemetryService, TelemetryEvent } from "../interfaces/telemetry";
+import { CacheService } from "../interfaces/cacheService";
+import { ConfigurationManager } from "./configurationManager";
+import { IdManager } from "../interfaces/idManager";
+import { Environment } from "../interfaces/environment";
+import { enhance, isError } from "../utils/events";
 
 /**
  * Implementation of a `TelemetryService`
@@ -15,12 +15,14 @@ import { enhance, isError } from '../utils/events';
 export class TelemetryServiceImpl implements TelemetryService {
   private startTime: number;
 
-  constructor(private reporter: Reporter, 
-              private queue: TelemetryEventQueue | undefined, 
-              private settings: TelemetrySettings, 
-              private idManager: IdManager, 
-              private environment: Environment,
-              private configurationManager?: ConfigurationManager) {
+  constructor(
+    private reporter: Reporter,
+    private queue: TelemetryEventQueue | undefined,
+    private settings: TelemetrySettings,
+    private idManager: IdManager,
+    private environment: Environment,
+    private configurationManager?: ConfigurationManager,
+  ) {
     this.startTime = this.getCurrentTimeInSeconds();
   }
 
@@ -43,19 +45,22 @@ export class TelemetryServiceImpl implements TelemetryService {
 
   public async sendStartupEvent(): Promise<void> {
     this.startTime = this.getCurrentTimeInSeconds();
-    return this.send({ name: 'startup' });
+    return this.send({ name: "startup" });
   }
   public async sendShutdownEvent(): Promise<void> {
-    return this.send({ name: 'shutdown', properties: {
-      //Sends session duration in seconds
-      session_duration: this.getCurrentTimeInSeconds() - this.startTime
-    } });
+    return this.send({
+      name: "shutdown",
+      properties: {
+        //Sends session duration in seconds
+        session_duration: this.getCurrentTimeInSeconds() - this.startTime,
+      },
+    });
   }
 
   private async sendEvent(event: TelemetryEvent): Promise<void> {
     //Check against VS Code settings
     const level = this.settings.getTelemetryLevel();
-    if (level && ["error","crash"].includes(level) && !isError(event)) {
+    if (level && ["error", "crash"].includes(level) && !isError(event)) {
       return;
     }
 
@@ -66,7 +71,7 @@ export class TelemetryServiceImpl implements TelemetryService {
       properties: event.properties,
       measures: event.measures,
       traits: event.traits,
-      context: event.context
+      context: event.context,
     };
 
     //Check against Extension configuration
@@ -95,9 +100,8 @@ export class TelemetryServiceImpl implements TelemetryService {
     return this.reporter.flush();
   }
 
-
   private getCurrentTimeInSeconds(): number {
     const now = Date.now();
-    return Math.floor(now/1000);
+    return Math.floor(now / 1000);
   }
 }

--- a/src/tests/config/telemetry-config.json
+++ b/src/tests/config/telemetry-config.json
@@ -1,22 +1,22 @@
 {
-    "*": {
-        "enabled":"all",
-        "refresh": "2h",
-        "ratio": "1",
-        "includes": [
-            {
-                "name" : "*"
-            }
-        ]
-    },
-    "redhat.vscode-hypothetical": {
-        "enabled": "errors",
-        "ratio": "0.5",
-        "excludes": [
-            {
-                "property": "error",
-                "value": "*stackoverflow*"
-            }
-        ]
-    }
+  "*": {
+    "enabled": "all",
+    "refresh": "2h",
+    "ratio": "1",
+    "includes": [
+      {
+        "name": "*"
+      }
+    ]
+  },
+  "redhat.vscode-hypothetical": {
+    "enabled": "errors",
+    "ratio": "0.5",
+    "excludes": [
+      {
+        "property": "error",
+        "value": "*stackoverflow*"
+      }
+    ]
+  }
 }

--- a/src/tests/gitpod/gitpodIdManager.test.ts
+++ b/src/tests/gitpod/gitpodIdManager.test.ts
@@ -1,32 +1,32 @@
-import * as assert from 'assert';
-import mock from 'mock-fs';
-import { GitpodIdManager } from '../../gitpod/gitpodIdManager';
-import env from '../../interfaces/envVar';
-import { UUID } from '../../utils/uuid';
+import * as assert from "assert";
+import mock from "mock-fs";
+import { GitpodIdManager } from "../../gitpod/gitpodIdManager";
+import env from "../../interfaces/envVar";
+import { UUID } from "../../utils/uuid";
 
 const redhatDir = `${process.cwd()}/.redhat/`;
 
-suite('Test gitpod id manager', () => {
-  setup(() => {  
-      mock({
-        '.redhat': {
-          'anonymousId': 'some-uuid'
-        }
-      });
+suite("Test gitpod id manager", () => {
+  setup(() => {
+    mock({
+      ".redhat": {
+        anonymousId: "some-uuid",
+      },
     });
-    teardown(() => {
-        mock.restore();
-    });
-    test('Should generate Red Hat UUID from GITPOD_GIT_USER_EMAIL env', async () => {
-      env.GITPOD_GIT_USER_EMAIL = 'some.user@company.com';
-      console.log(env.GITPOD_GIT_USER_EMAIL);
-      const gitpod = new GitpodIdManager();
-      const id = gitpod.loadRedHatUUID(redhatDir);
-      const expectedId = '465b7cd6-0f77-5fc8-97ed-7b6342df109f';
-      assert.strictEqual(id, expectedId);
+  });
+  teardown(() => {
+    mock.restore();
+  });
+  test("Should generate Red Hat UUID from GITPOD_GIT_USER_EMAIL env", async () => {
+    env.GITPOD_GIT_USER_EMAIL = "some.user@company.com";
+    console.log(env.GITPOD_GIT_USER_EMAIL);
+    const gitpod = new GitpodIdManager();
+    const id = gitpod.loadRedHatUUID(redhatDir);
+    const expectedId = "465b7cd6-0f77-5fc8-97ed-7b6342df109f";
+    assert.strictEqual(id, expectedId);
 
-      //Check anonymousId file was updated
-      const anonymousId = UUID.readFile(UUID.getAnonymousIdFile(redhatDir));
-      assert.strictEqual(anonymousId, id);
-    });
+    //Check anonymousId file was updated
+    const anonymousId = UUID.readFile(UUID.getAnonymousIdFile(redhatDir));
+    assert.strictEqual(anonymousId, id);
+  });
 });

--- a/src/tests/services/configuration.test.ts
+++ b/src/tests/services/configuration.test.ts
@@ -1,123 +1,132 @@
 import assert from "assert";
 import { AnalyticsEvent } from "../../services/AnalyticsEvent";
 import { Configuration } from "../../services/configuration";
-import { v4 } from 'uuid';
+import { v4 } from "uuid";
 import { hashCode, numValue } from "../../utils/hashcode";
-suite('Test configurations', () => {
+suite("Test configurations", () => {
+  const all = {
+    enabled: "all",
+    includes: [
+      {
+        name: "*",
+      },
+    ],
+  };
 
-    const all = {
-        "enabled": "all",
-        "includes": [
-            {
-                "name": "*"
-            }
-        ]
-    };
+  const identify = {
+    enabled: "all",
+    includes: [
+      {
+        name: "identify",
+      },
+    ],
+  };
 
-    const identify = {
-        "enabled": "all",
-        "includes": [
-            {
-                "name": "identify"
-            }
-        ]
-    };
+  const off = {
+    enabled: "off",
+    includes: [
+      {
+        name: "*",
+      },
+    ],
+  };
 
-    const off = {
-        "enabled": "off",
-        "includes": [
-            {
-                "name": "*"
-            }
-        ]
-    };
+  const errors = {
+    enabled: "error",
+    excludes: [
+      {
+        property: "error",
+        value: "*stackoverflow*",
+      },
+    ],
+  };
 
-    const errors = {
-        "enabled": "error",
-        "excludes": [
-            {
-                "property": "error",
-                "value": "*stackoverflow*"
-            }
-        ]
-    }
+  const ratioed = {
+    ratio: "0.3",
+  };
 
-    const ratioed = {
-        "ratio":"0.3"
-    };
+  test("Should allow all events", async () => {
+    const config = new Configuration(all);
+    let event = { event: "something" } as AnalyticsEvent;
+    assert.ok(config.canSend(event) === true);
+  });
 
+  test("Should not allow any events", async () => {
+    const config = new Configuration(off);
+    let event = { event: "something" } as AnalyticsEvent;
+    assert.ok(config.canSend(event) === false);
+  });
 
-    test('Should allow all events', async () => {
-        const config = new Configuration(all);
-        let event = { event: "something" } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === true);
-    });
+  test("Should filter events by name", async () => {
+    const config = new Configuration(identify);
+    let event = {
+      event: "identify",
+    } as AnalyticsEvent;
+    assert.ok(config.canSend(event) === true);
+    event = {
+      event: "startup",
+    } as AnalyticsEvent;
+    assert.ok(config.canSend(event) === false);
+  });
 
-    test('Should not allow any events', async () => {
-        const config = new Configuration(off);
-        let event = { event: "something" } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === false);
-    });
+  test("Should only allow errors", async () => {
+    const config = new Configuration(errors);
+    let event = {
+      event: "startup",
+    } as AnalyticsEvent;
+    assert.ok(
+      config.canSend(event) === false,
+      `${event.event} shouldn't be sent`,
+    );
+    event = {
+      event: "failed-analysis",
+      properties: {
+        error: "Ohoh, an error occurred!",
+      },
+    } as AnalyticsEvent;
+    assert.ok(config.canSend(event) === true, `${event.event} should be sent`);
+    event = {
+      event: "crash-analysis",
+      properties: {
+        error: "Bla bla stackoverflow bla",
+      },
+    } as AnalyticsEvent;
+    assert.ok(
+      config.canSend(event) === false,
+      `${event.event} shouldn't be sent`,
+    );
+  });
 
-    test('Should filter events by name', async () => {
-        const config = new Configuration(identify);
-        let event = {
-            event: "identify"
-         } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === true);
-        event = {
-            event: "startup"
-        } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === false);
-    });
+  test("Should only allow errors", async () => {
+    const config = new Configuration(errors);
+    let event = {
+      event: "startup",
+    } as AnalyticsEvent;
+    assert.ok(
+      config.canSend(event) === false,
+      `${event.event} shouldn't be sent`,
+    );
+    event = {
+      event: "failed-analysis",
+      properties: {
+        error: "Ohoh, an error occurred!",
+      },
+    } as AnalyticsEvent;
+    assert.ok(config.canSend(event) === true, `${event.event} should be sent`);
+    event = {
+      event: "crash-analysis",
+      properties: {
+        error: "Bla bla stackoverflow bla",
+      },
+    } as AnalyticsEvent;
+    assert.ok(
+      config.canSend(event) === false,
+      `${event.event} shouldn't be sent`,
+    );
+  });
 
-    test('Should only allow errors', async () => {
-        const config = new Configuration(errors);
-        let event = {
-            event: "startup"
-         } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === false, `${event.event} shouldn't be sent`);
-        event = {
-            event: "failed-analysis",
-            properties: {
-                "error": "Ohoh, an error occurred!"
-            }
-        } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === true, `${event.event} should be sent`);
-        event = {
-            event: "crash-analysis",
-            properties: {
-                "error": "Bla bla stackoverflow bla"
-            }
-        } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === false, `${event.event} shouldn't be sent`);
-    });
-
-    test('Should only allow errors', async () => {
-        const config = new Configuration(errors);
-        let event = {
-            event: "startup"
-         } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === false, `${event.event} shouldn't be sent`);
-        event = {
-            event: "failed-analysis",
-            properties: {
-                "error": "Ohoh, an error occurred!"
-            }
-        } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === true, `${event.event} should be sent`);
-        event = {
-            event: "crash-analysis",
-            properties: {
-                "error": "Bla bla stackoverflow bla"
-            }
-        } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === false, `${event.event} shouldn't be sent`);
-    });
-
-
-    test('Should apply ratio on userId', async () => {
-        /*
+  test("Should apply ratio on userId", async () => {
+    /*
         d0b7ac12-caa0-4253-8087-788ff0b1c293 hashcode:-1654400659 numvalue:0.59
         8668869d-a068-412b-9e59-4fec9dc0483a hashcode:-1782924593 numvalue:0.93
         8b7fe10d-bb9d-434c-afed-4fb03f3b626e hashcode:1373002981 numvalue:0.81
@@ -130,21 +139,27 @@ suite('Test configurations', () => {
         cd304b68-3512-4af5-8991-377479bfede6 hashcode:-449137339 numvalue:0.39
         */
 
-        const config = new Configuration(ratioed);
-        let event = {
-            userId: "d0b7ac12-caa0-4253-8087-788ff0b1c293", //numvalue:0.59 > 0.3
-            event: "startup"
-         } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === false, `${event.event} shouldn't be sent`);
-        event = {
-            userId: "533629ec-091b-474b-95e6-3aa0eef3e940",//numvalue:0.22 < 0.3
-            event: "startup",
-        } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === true, `${event.event} should be sent`);
-        event = {
-            userId: "cd304b68-3512-4af5-8991-377479bfede6",//numvalue:0.39 > 0.3
-            event: "startup",
-        } as AnalyticsEvent;
-        assert.ok(config.canSend(event) === false, `${event.event} shouldn't be sent`);
-    });
+    const config = new Configuration(ratioed);
+    let event = {
+      userId: "d0b7ac12-caa0-4253-8087-788ff0b1c293", //numvalue:0.59 > 0.3
+      event: "startup",
+    } as AnalyticsEvent;
+    assert.ok(
+      config.canSend(event) === false,
+      `${event.event} shouldn't be sent`,
+    );
+    event = {
+      userId: "533629ec-091b-474b-95e6-3aa0eef3e940", //numvalue:0.22 < 0.3
+      event: "startup",
+    } as AnalyticsEvent;
+    assert.ok(config.canSend(event) === true, `${event.event} should be sent`);
+    event = {
+      userId: "cd304b68-3512-4af5-8991-377479bfede6", //numvalue:0.39 > 0.3
+      event: "startup",
+    } as AnalyticsEvent;
+    assert.ok(
+      config.canSend(event) === false,
+      `${event.event} shouldn't be sent`,
+    );
+  });
 });

--- a/src/tests/services/configurationManager.test.ts
+++ b/src/tests/services/configurationManager.test.ts
@@ -1,158 +1,173 @@
 import assert from "assert";
-import axios from 'axios';
-import mockFS from 'mock-fs';
-import * as fs from 'fs';
-import MockAdapter from 'axios-mock-adapter';
+import axios from "axios";
+import mockFS from "mock-fs";
+import * as fs from "fs";
+import MockAdapter from "axios-mock-adapter";
 import { afterEach, beforeEach } from "mocha";
-import { ConfigurationManager, DEFAULT_CONFIG_URL, TELEMETRY_CONFIG } from "../../services/configurationManager";
+import {
+  ConfigurationManager,
+  DEFAULT_CONFIG_URL,
+  TELEMETRY_CONFIG,
+} from "../../services/configurationManager";
 import { FileSystemStorageService } from "../../services/FileSystemStorageService";
 import path from "path";
 import env from "../../interfaces/envVar";
 
-suite('Test configuration manager', () => {
+suite("Test configuration manager", () => {
+  let mockAxios: MockAdapter;
+  let configurationManager: ConfigurationManager;
 
-    let mockAxios: MockAdapter;
-    let configurationManager: ConfigurationManager;
-    
-    const cacheDir = `${process.cwd()}/extension/cache`;
+  const cacheDir = `${process.cwd()}/extension/cache`;
 
-    const storageService = new FileSystemStorageService(cacheDir);
+  const storageService = new FileSystemStorageService(cacheDir);
 
-    const remoteConfig = {
-        "*": {
-            "enabled":"all",
-            "refresh": "3h",
-            "ratio": "1",
-            "includes": [
-                {
-                    "name" : "*"
-                }
-            ]
+  const remoteConfig = {
+    "*": {
+      enabled: "all",
+      refresh: "3h",
+      ratio: "1",
+      includes: [
+        {
+          name: "*",
         },
-        "redhat.vscode-yaml":{
-            "enabled": "errors",
-            "ratio": "0.5",
-            "excludes": [
-                {
-                    "property": "error",
-                    "value": "*stackoverflow*"
-                }
-            ]
+      ],
+    },
+    "redhat.vscode-yaml": {
+      enabled: "errors",
+      ratio: "0.5",
+      excludes: [
+        {
+          property: "error",
+          value: "*stackoverflow*",
         },
-        "redhat.vscode-hypothetical": {
-            "enabled": "off"
-        }
-    }
+      ],
+    },
+    "redhat.vscode-hypothetical": {
+      enabled: "off",
+    },
+  };
 
-    beforeEach(() => {
-        mockFS({
-                'extension/cache': {}
-        });
-        configurationManager = new ConfigurationManager('redhat.vscode-hypothetical', storageService);
-        mockAxios = new MockAdapter(axios);
-        mockAxios.onGet(DEFAULT_CONFIG_URL).replyOnce(200, remoteConfig);
+  beforeEach(() => {
+    mockFS({
+      "extension/cache": {},
     });
+    configurationManager = new ConfigurationManager(
+      "redhat.vscode-hypothetical",
+      storageService,
+    );
+    mockAxios = new MockAdapter(axios);
+    mockAxios.onGet(DEFAULT_CONFIG_URL).replyOnce(200, remoteConfig);
+  });
 
-    afterEach(() => {
-        env[ConfigurationManager.TEST_CONFIG_KEY] = undefined;
-        mockAxios.reset();
-        mockAxios.restore();
-        mockFS.restore();
-    });   
+  afterEach(() => {
+    env[ConfigurationManager.TEST_CONFIG_KEY] = undefined;
+    mockAxios.reset();
+    mockAxios.restore();
+    mockFS.restore();
+  });
 
-    test('Should download remote config', async () => {
-        const json = await configurationManager.fetchRemoteConfiguration();
-        assert.deepStrictEqual(json, remoteConfig);
+  test("Should download remote config", async () => {
+    const json = await configurationManager.fetchRemoteConfiguration();
+    assert.deepStrictEqual(json, remoteConfig);
+  });
+
+  test("Should update stale config", async () => {
+    const origTimestamp = "12345678";
+    mockFS.restore();
+    mockFS({
+      "extension/cache": {
+        "telemetry-config.json":
+          "{" +
+          '"*": {' +
+          '"enabled":"errors",' +
+          '"timestamp" : "12345678",' +
+          '"refresh": "12h"' +
+          "}" +
+          "}",
+      },
     });
+    const config = await configurationManager.getExtensionConfiguration();
+    const referenceTimestamp = config.json.timestamp;
+    assert.notStrictEqual(referenceTimestamp, origTimestamp);
+    assert.strictEqual(config.json.enabled, "off");
 
-    test('Should update stale config', async ()=> {
-        const origTimestamp = '12345678';
-        mockFS.restore();
-        mockFS({
-            'extension/cache': {
-                'telemetry-config.json': '{'+
-                        '"*": {'+
-                            '"enabled":"errors",'+
-                            '"timestamp" : "12345678",'+
-                            '"refresh": "12h"'+
-                        '}'+
-                    '}'
-            }
-        });
-        const config = await configurationManager.getExtensionConfiguration();
-        const referenceTimestamp = config.json.timestamp;
-        assert.notStrictEqual(referenceTimestamp, origTimestamp);
-        assert.strictEqual(config.json.enabled, 'off');
-        
-        const configPath = path.join(cacheDir, TELEMETRY_CONFIG);
-        const jsonConfig = JSON.parse(fs.readFileSync(configPath, { encoding: 'utf8' }));
-        assert.strictEqual(jsonConfig.timestamp, referenceTimestamp);
-    });
+    const configPath = path.join(cacheDir, TELEMETRY_CONFIG);
+    const jsonConfig = JSON.parse(
+      fs.readFileSync(configPath, { encoding: "utf8" }),
+    );
+    assert.strictEqual(jsonConfig.timestamp, referenceTimestamp);
+  });
 
-    test('Should store remote content locally', async ()=> {
-        const filePath = path.join(cacheDir, TELEMETRY_CONFIG);
-        assert.ok(!fs.existsSync(filePath), `${TELEMETRY_CONFIG} should not exist`);
+  test("Should store remote content locally", async () => {
+    const filePath = path.join(cacheDir, TELEMETRY_CONFIG);
+    assert.ok(!fs.existsSync(filePath), `${TELEMETRY_CONFIG} should not exist`);
 
-        const config1 = await configurationManager.getExtensionConfiguration();
-        assert.ok(fs.existsSync(filePath), `${TELEMETRY_CONFIG} should exist`);
-        const referenceTimestamp = config1.json.timestamp;
-        
-        //No http request was made here
-        configurationManager = new ConfigurationManager('redhat.vscode-other', storageService);
-        const config = await configurationManager.getExtensionConfiguration();
-        assert.strictEqual(config.json.timestamp, referenceTimestamp);//Same timestamp
-        delete config.json['timestamp'];
-        assert.deepStrictEqual(config.json ,{
-            "refresh": "3h",
-            "includes": [
-                {
-                    "name" : "*"
-                }
-            ],
-            "enabled": "all",
-            "ratio": "1"
-        });
-    });
+    const config1 = await configurationManager.getExtensionConfiguration();
+    assert.ok(fs.existsSync(filePath), `${TELEMETRY_CONFIG} should exist`);
+    const referenceTimestamp = config1.json.timestamp;
 
-    test('Should inherit config', async () => {
-        configurationManager = new ConfigurationManager('random-vscode', storageService);
-        const config = await configurationManager.getExtensionConfiguration();
-        assert.ok(config.json.timestamp);
-        delete config.json['timestamp'];
-        assert.deepStrictEqual(config.json ,{
-            "enabled":"all",
-            "refresh": "3h",
-            "ratio": "1",
-            "includes": [
-                {
-                    "name" : "*"
-                }
-            ]
-        },);
+    //No http request was made here
+    configurationManager = new ConfigurationManager(
+      "redhat.vscode-other",
+      storageService,
+    );
+    const config = await configurationManager.getExtensionConfiguration();
+    assert.strictEqual(config.json.timestamp, referenceTimestamp); //Same timestamp
+    delete config.json["timestamp"];
+    assert.deepStrictEqual(config.json, {
+      refresh: "3h",
+      includes: [
+        {
+          name: "*",
+        },
+      ],
+      enabled: "all",
+      ratio: "1",
     });
-    
-    test('Should read embedded config', async () => {
-        mockFS.restore();
-        env[ConfigurationManager.TEST_CONFIG_KEY] = 'true';
-        mockAxios.reset();
-        mockAxios.onGet(DEFAULT_CONFIG_URL).reply(404); 
-        
-        const config = await configurationManager.getExtensionConfiguration();
-        assert.deepStrictEqual(config.json ,{
-            "refresh": "2h",
-            "includes": [
-                {
-                    "name" : "*"
-                }
-            ],
-            "enabled": "errors",
-            "ratio": "0.5",
-            "excludes": [
-                {
-                    "property": "error",
-                    "value": "*stackoverflow*"
-                }
-            ]
-        });
+  });
+
+  test("Should inherit config", async () => {
+    configurationManager = new ConfigurationManager(
+      "random-vscode",
+      storageService,
+    );
+    const config = await configurationManager.getExtensionConfiguration();
+    assert.ok(config.json.timestamp);
+    delete config.json["timestamp"];
+    assert.deepStrictEqual(config.json, {
+      enabled: "all",
+      refresh: "3h",
+      ratio: "1",
+      includes: [
+        {
+          name: "*",
+        },
+      ],
     });
+  });
+
+  test("Should read embedded config", async () => {
+    mockFS.restore();
+    env[ConfigurationManager.TEST_CONFIG_KEY] = "true";
+    mockAxios.reset();
+    mockAxios.onGet(DEFAULT_CONFIG_URL).reply(404);
+
+    const config = await configurationManager.getExtensionConfiguration();
+    assert.deepStrictEqual(config.json, {
+      refresh: "2h",
+      includes: [
+        {
+          name: "*",
+        },
+      ],
+      enabled: "errors",
+      ratio: "0.5",
+      excludes: [
+        {
+          property: "error",
+          value: "*stackoverflow*",
+        },
+      ],
+    });
+  });
 });

--- a/src/tests/services/fileSystemCacheService.test.ts
+++ b/src/tests/services/fileSystemCacheService.test.ts
@@ -1,19 +1,19 @@
-import mockFS from 'mock-fs';
-import * as fs from 'fs';
+import mockFS from "mock-fs";
+import * as fs from "fs";
 import path from "path";
-import * as assert from 'assert';
-import { FileSystemCacheService } from '../../services/fileSystemCacheService';
+import * as assert from "assert";
+import { FileSystemCacheService } from "../../services/fileSystemCacheService";
 
 let cacheService: FileSystemCacheService;
 
 const cacheDir = `${process.cwd()}/extension/cache`;
 
-suite('Test cache service', () => {
+suite("Test cache service", () => {
   setup(() => {
     mockFS({
-      'extension/cache': {
-        'identity.txt': 'hash'
-      }
+      "extension/cache": {
+        "identity.txt": "hash",
+      },
     });
 
     cacheService = new FileSystemCacheService(cacheDir);
@@ -21,31 +21,30 @@ suite('Test cache service', () => {
   teardown(() => {
     mockFS.restore();
   });
-  test('Should create cache directory recursively', async () => {
-    const cacheDir = `${process.cwd()}/extensions/cache/` + new Date().getTime();
+  test("Should create cache directory recursively", async () => {
+    const cacheDir =
+      `${process.cwd()}/extensions/cache/` + new Date().getTime();
     cacheService = new FileSystemCacheService(cacheDir);
-    const filePath = path.join(cacheDir, 'something.txt');
-    await cacheService.put('something', 'hash');
-    assert.ok(fs.existsSync(filePath), 'something.txt should exist');
-
+    const filePath = path.join(cacheDir, "something.txt");
+    await cacheService.put("something", "hash");
+    assert.ok(fs.existsSync(filePath), "something.txt should exist");
   });
-  test('Should read data from FS', async () => {
-    let data = await cacheService.get('identity');
-    assert.strictEqual(data, 'hash');
-    const filePath = path.join(cacheDir, 'identity.txt');
+  test("Should read data from FS", async () => {
+    let data = await cacheService.get("identity");
+    assert.strictEqual(data, "hash");
+    const filePath = path.join(cacheDir, "identity.txt");
 
     // Delete underlying file and check data is read from memory from now on
     fs.unlinkSync(filePath);
-    data = await cacheService.get('identity');
-    assert.strictEqual(data, 'hash');
-    assert.ok(!fs.existsSync(filePath), 'identity.txt should not exist');
-
+    data = await cacheService.get("identity");
+    assert.strictEqual(data, "hash");
+    assert.ok(!fs.existsSync(filePath), "identity.txt should not exist");
   });
 
-  test('Should write data to FS', async () => {
-    const filePath = path.join(cacheDir, 'something.txt');
-    assert.ok(!fs.existsSync(filePath), 'something.txt should not exist');
-    await cacheService.put('something', 'hash');
-    assert.ok(fs.existsSync(filePath), 'something.txt should exist');
+  test("Should write data to FS", async () => {
+    const filePath = path.join(cacheDir, "something.txt");
+    assert.ok(!fs.existsSync(filePath), "something.txt should not exist");
+    await cacheService.put("something", "hash");
+    assert.ok(fs.existsSync(filePath), "something.txt should exist");
   });
 });

--- a/src/tests/utils/events.test.ts
+++ b/src/tests/utils/events.test.ts
@@ -1,99 +1,111 @@
-import * as utils from '../../utils/events';
-import * as assert from 'assert';
-import { Environment } from '../../interfaces/environment';
-import { TelemetryEvent } from '../..';
+import * as utils from "../../utils/events";
+import * as assert from "assert";
+import { Environment } from "../../interfaces/environment";
+import { TelemetryEvent } from "../..";
 
 const env: Environment = {
-    application: {
-        name:'SuperCode',
-        version:'6.6.6'
-    },
-    extension: {
-        name: 'my-ext',
-        version: '1.2.3'
-    },
-    username:'Fred',
-    platform: {
-        name: 'DeathStar II'
-    },
-}
+  application: {
+    name: "SuperCode",
+    version: "6.6.6",
+  },
+  extension: {
+    name: "my-ext",
+    version: "1.2.3",
+  },
+  username: "Fred",
+  platform: {
+    name: "DeathStar II",
+  },
+};
 
-suite('Test events enhancements', () => {
-    test('should inject environment data', async () => {
-        const event: TelemetryEvent = {
-            name:'Something',
-            properties: {
-                foo: 'bar',
-            }
-        }
+suite("Test events enhancements", () => {
+  test("should inject environment data", async () => {
+    const event: TelemetryEvent = {
+      name: "Something",
+      properties: {
+        foo: "bar",
+      },
+    };
 
-        const betterEvent = utils.enhance(event, env);
-        assert.strictEqual(betterEvent.properties.app_name, 'SuperCode');
-        assert.strictEqual(betterEvent.properties.app_version, '6.6.6');
-        assert.strictEqual(betterEvent.properties.extension_name, 'my-ext');
-        assert.strictEqual(betterEvent.properties.extension_version, '1.2.3');
-        assert.strictEqual(betterEvent.properties.foo, 'bar');
-        assert.strictEqual(betterEvent.context.ip, '0.0.0.0');
+    const betterEvent = utils.enhance(event, env);
+    assert.strictEqual(betterEvent.properties.app_name, "SuperCode");
+    assert.strictEqual(betterEvent.properties.app_version, "6.6.6");
+    assert.strictEqual(betterEvent.properties.extension_name, "my-ext");
+    assert.strictEqual(betterEvent.properties.extension_version, "1.2.3");
+    assert.strictEqual(betterEvent.properties.foo, "bar");
+    assert.strictEqual(betterEvent.context.ip, "0.0.0.0");
+  });
 
+  test("should anonymize data", async () => {
+    const event: TelemetryEvent = {
+      name: "Something",
+      properties: {
+        foo: "Fred is Fred",
+        qty: 10,
+        active: false,
+        bar: "That c:\\Fred\\bar looks like a path",
+        error: "An error occurred in /Users/Fred/foo/bar.txt! But we're fine",
+        multiline:
+          "That url file://Fred/bar.txt is gone!\nNot that c:\\user\\bar though",
+        obj: {
+          q: "Who is Fred?",
+          a: "Fred who?",
+        },
+      },
+    };
+
+    const betterEvent = utils.enhance(event, env);
+
+    assert.strictEqual(betterEvent.properties.qty, 10);
+    assert.strictEqual(betterEvent.properties.active, false);
+    assert.strictEqual(betterEvent.properties.foo, "_username_ is _username_");
+    assert.strictEqual(
+      betterEvent.properties.bar,
+      "That c:\\_username_\\bar looks like a path",
+    );
+    assert.strictEqual(
+      betterEvent.properties.error,
+      "An error occurred in /Users/_username_/foo/bar.txt! But we're fine",
+    );
+    assert.strictEqual(
+      betterEvent.properties.multiline,
+      "That url file://_username_/bar.txt is gone!\nNot that c:\\user\\bar though",
+    );
+    assert.strictEqual(betterEvent.properties.obj.q, "Who is _username_?");
+    assert.strictEqual(betterEvent.properties.obj.a, "_username_ who?");
+  });
+
+  test("should not anonymize special usernames", async () => {
+    utils.IGNORED_USERS.forEach((user) => {
+      const cheEnv: Environment = {
+        application: {
+          name: "SuperCode",
+          version: "6.6.6",
+        },
+        extension: {
+          name: "my-ext",
+          version: "1.2.3",
+        },
+        username: user,
+        platform: {
+          name: "DeathStar II",
+        },
+      };
+
+      const event: TelemetryEvent = {
+        name: "Something",
+        properties: {
+          foo: "user likes theia",
+          multiline: "That gitpod \nusername is woke",
+        },
+      };
+
+      const betterEvent = utils.enhance(event, cheEnv);
+      assert.strictEqual(betterEvent.properties.foo, event.properties.foo);
+      assert.strictEqual(
+        betterEvent.properties.multiline,
+        event.properties.multiline,
+      );
     });
-
-    test('should anonymize data', async () => {
-        const event: TelemetryEvent = {
-            name:'Something',
-            properties: {
-                foo: 'Fred is Fred',
-                qty: 10,
-                active: false,
-                bar: 'That c:\\Fred\\bar looks like a path',
-                error: 'An error occurred in /Users/Fred/foo/bar.txt! But we\'re fine',
-                multiline: 'That url file://Fred/bar.txt is gone!\nNot that c:\\user\\bar though',
-                obj: {
-                    q: 'Who is Fred?',
-                    a: 'Fred who?'
-                }
-            }
-        }
-
-        const betterEvent = utils.enhance(event, env);
-
-        assert.strictEqual(betterEvent.properties.qty, 10);
-        assert.strictEqual(betterEvent.properties.active, false);
-        assert.strictEqual(betterEvent.properties.foo, '_username_ is _username_');
-        assert.strictEqual(betterEvent.properties.bar, 'That c:\\_username_\\bar looks like a path');
-        assert.strictEqual(betterEvent.properties.error, 'An error occurred in /Users/_username_/foo/bar.txt! But we\'re fine');
-        assert.strictEqual(betterEvent.properties.multiline, 'That url file://_username_/bar.txt is gone!\nNot that c:\\user\\bar though');
-        assert.strictEqual(betterEvent.properties.obj.q, 'Who is _username_?');
-        assert.strictEqual(betterEvent.properties.obj.a, '_username_ who?');
-    });
-
-    test('should not anonymize special usernames', async () => {
-        utils.IGNORED_USERS.forEach((user) => {
-            const cheEnv: Environment = {
-                application: {
-                    name:'SuperCode',
-                    version:'6.6.6'
-                },
-                extension: {
-                    name: 'my-ext',
-                    version: '1.2.3'
-                },
-                username: user,
-                platform: {
-                    name: 'DeathStar II'
-                },
-            }
-
-            const event: TelemetryEvent = {
-                name:'Something',
-                properties: {
-                    foo: 'user likes theia',
-                    multiline: 'That gitpod \nusername is woke',
-                }
-            }
-
-            const betterEvent = utils.enhance(event, cheEnv);
-            assert.strictEqual(betterEvent.properties.foo, event.properties.foo);
-            assert.strictEqual(betterEvent.properties.multiline, event.properties.multiline);
-        });
-    });
+  });
 });

--- a/src/tests/utils/geolocation.test.ts
+++ b/src/tests/utils/geolocation.test.ts
@@ -1,12 +1,12 @@
-import * as assert from 'assert';
-import { getCountry } from '../../utils/geolocation';
+import * as assert from "assert";
+import { getCountry } from "../../utils/geolocation";
 
-suite('Test get country from timezone', () => {
-    test('known country', async () => {
-        assert.strictEqual('FR', getCountry("Europe/Paris"));
-    });
-    test('unknown country', async () => {
-        assert.strictEqual('ZZ', getCountry(""));
-        assert.strictEqual('ZZ', getCountry("Groland/Groville"));
-    });
+suite("Test get country from timezone", () => {
+  test("known country", async () => {
+    assert.strictEqual("FR", getCountry("Europe/Paris"));
+  });
+  test("unknown country", async () => {
+    assert.strictEqual("ZZ", getCountry(""));
+    assert.strictEqual("ZZ", getCountry("Groland/Groville"));
+  });
 });

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -1,13 +1,13 @@
 import path from "path";
-import * as fs from 'fs';
+import * as fs from "fs";
 
 export function getExtensionId(packageJson: any): string {
-    return `${packageJson.publisher}.${packageJson.name}`;
+  return `${packageJson.publisher}.${packageJson.name}`;
 }
 
 export function loadPackageJson(extensionPath: string): any {
-    const packageJsonPath = path.resolve(extensionPath, 'package.json')
-    const rawdata = fs.readFileSync(packageJsonPath, { encoding: 'utf8' });
-    const packageJson = JSON.parse(rawdata);
-    return packageJson;
+  const packageJsonPath = path.resolve(extensionPath, "package.json");
+  const rawdata = fs.readFileSync(packageJsonPath, { encoding: "utf8" });
+  const packageJson = JSON.parse(rawdata);
+  return packageJson;
 }

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -1,10 +1,9 @@
-
-import { getTimezone } from 'countries-and-timezones';
+import { getTimezone } from "countries-and-timezones";
 export function getCountry(timezone: string): string {
-    const tz = getTimezone(timezone);
-    if (tz && tz?.country) {
-        return tz.country;
-    }
-    //Probably UTC timezone
-    return 'ZZ'; //Unknown country
-} 
+  const tz = getTimezone(timezone);
+  if (tz && tz?.country) {
+    return tz.country;
+  }
+  //Probably UTC timezone
+  return "ZZ"; //Unknown country
+}

--- a/src/utils/hashcode.ts
+++ b/src/utils/hashcode.ts
@@ -1,25 +1,24 @@
 //See https://stackoverflow.com/a/8076436/753170
-export function hashCode(value: string) : number {
-    let hash = 0;
-    for (let i = 0; i < value.length; i++) {
-        const code = value.charCodeAt(i);
-        hash = ((hash<<5)-hash)+code;
-        hash = hash & hash; // Convert to 32bit integer
-    }
-    return hash;
+export function hashCode(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    hash = (hash << 5) - hash + code;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return hash;
 }
-
 
 const cache = new Map<string, number>();
 
-export function numValue(value: string) : number {
-    let num = cache.get(value);
-    if (num) {
-        return num;
-    }
-    const hash = Math.abs(hashCode(value)).toString();
-    const x = Math.min(2, hash.length);
-    num = parseFloat(hash.substring(hash.length - x))/100;
-    cache.set(value, num);
+export function numValue(value: string): number {
+  let num = cache.get(value);
+  if (num) {
     return num;
+  }
+  const hash = Math.abs(hashCode(value)).toString();
+  const x = Math.min(2, hash.length);
+  num = parseFloat(hash.substring(hash.length - x)) / 100;
+  cache.set(value, num);
+  return num;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,13 +1,12 @@
 import envVars from "../interfaces/envVar";
 
-export let doLog: boolean = envVars.VSCODE_REDHAT_TELEMETRY_DEBUG === 'true';
+export let doLog: boolean = envVars.VSCODE_REDHAT_TELEMETRY_DEBUG === "true";
 
 // This exists only for testing purposes. Could delete later.
-const VERSION = require('../../package.json').version;
-
+const VERSION = require("../../package.json").version;
 
 export namespace Logger {
-  export let extId = 'unknown';
+  export let extId = "unknown";
   export function log(s: number | string | boolean | undefined): void {
     if (doLog) {
       console.log(`vscode-redhat-telemetry ${VERSION} (${extId}): ${s}`);

--- a/src/utils/segmentInitializer.ts
+++ b/src/utils/segmentInitializer.ts
@@ -1,19 +1,18 @@
-import { Logger } from './logger';
-import Analytics from 'analytics-node';
-import { getExtensionId } from './extensions';
+import { Logger } from "./logger";
+import Analytics from "analytics-node";
+import { getExtensionId } from "./extensions";
 
 const IS_DEBUG = startedInDebugMode();
 
 let DEFAULT_SEGMENT_KEY: string | undefined;
 
 export namespace SegmentInitializer {
-  
   export function initialize(clientPackageJson: any): Analytics | undefined {
     let segmentWriteKey = getSegmentKey(clientPackageJson);
     if (!segmentWriteKey) {
       //Using the default key
       if (!DEFAULT_SEGMENT_KEY) {
-        const defaultPackageJson = require('../../package.json');
+        const defaultPackageJson = require("../../package.json");
         DEFAULT_SEGMENT_KEY = getSegmentKey(defaultPackageJson);
       }
       segmentWriteKey = DEFAULT_SEGMENT_KEY;
@@ -31,7 +30,9 @@ export namespace SegmentInitializer {
       });
       return analytics;
     } else {
-      Logger.log('Missing segmentWriteKey from package.json OR package.json in vscode-commons');
+      Logger.log(
+        "Missing segmentWriteKey from package.json OR package.json in vscode-commons",
+      );
       return undefined;
     }
   }
@@ -44,20 +45,22 @@ function startedInDebugMode(): boolean {
 
 // exported for tests
 function hasDebugFlag(args: string[]): boolean {
-  return args 
+  return (
+    args &&
     // See https://nodejs.org/en/docs/guides/debugging-getting-started/
-    && args.some(arg => /^--inspect/.test(arg) || /^--debug/.test(arg));
+    args.some((arg) => /^--inspect/.test(arg) || /^--debug/.test(arg))
+  );
 }
 
 function getSegmentKey(packageJson: any): string | undefined {
   const extensionId = getExtensionId(packageJson);
-  let keyKey = 'segmentWriteKeyDebug';
+  let keyKey = "segmentWriteKeyDebug";
   try {
     let clientSegmentKey: string | undefined = undefined;
     if (IS_DEBUG) {
       clientSegmentKey = packageJson[keyKey];
     } else {
-      keyKey = 'segmentWriteKey';
+      keyKey = "segmentWriteKey";
       clientSegmentKey = packageJson[keyKey];
     }
     if (clientSegmentKey) {

--- a/src/utils/telemetryEventQueue.ts
+++ b/src/utils/telemetryEventQueue.ts
@@ -1,4 +1,4 @@
-import { TelemetryEvent } from '../interfaces/telemetry';
+import { TelemetryEvent } from "../interfaces/telemetry";
 
 export const MAX_QUEUE_SIZE = 35;
 

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,11 +1,11 @@
-import * as os from 'os';
-import * as fs from 'fs';
-import * as path from 'path';
-import { v4, v5 } from 'uuid';
-import { Logger } from './logger';
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { v4, v5 } from "uuid";
+import { Logger } from "./logger";
 
 let REDHAT_ANONYMOUS_UUID: string | undefined;
-const REDHAT_NAMESPACE_UUID = '44662bc6-c388-4e0e-a652-53bda6f35923';
+const REDHAT_NAMESPACE_UUID = "44662bc6-c388-4e0e-a652-53bda6f35923";
 
 export namespace UUID {
   export function getRedHatUUID(redhatDir?: string): string {
@@ -18,13 +18,15 @@ export namespace UUID {
       if (REDHAT_ANONYMOUS_UUID) {
         Logger.log(`loaded Red Hat UUID: ${REDHAT_ANONYMOUS_UUID}`);
       } else {
-        Logger.log('No Red Hat UUID found');
+        Logger.log("No Red Hat UUID found");
         REDHAT_ANONYMOUS_UUID = v4();
         writeFile(redhatUUIDFilePath, REDHAT_ANONYMOUS_UUID);
-        Logger.log(`Written Red Hat UUID: ${REDHAT_ANONYMOUS_UUID} to ${redhatUUIDFilePath}`);
+        Logger.log(
+          `Written Red Hat UUID: ${REDHAT_ANONYMOUS_UUID} to ${redhatUUIDFilePath}`,
+        );
       }
     } catch (e: any) {
-      Logger.log('Failed to access Red Hat UUID: ' + e?.message);
+      Logger.log("Failed to access Red Hat UUID: " + e?.message);
     }
     return REDHAT_ANONYMOUS_UUID!;
   }
@@ -32,15 +34,15 @@ export namespace UUID {
   export function getAnonymousIdFile(redhatDir?: string): string {
     const homedir = os.homedir();
     if (!redhatDir) {
-      redhatDir = path.join(homedir, '.redhat');
+      redhatDir = path.join(homedir, ".redhat");
     }
-    return path.join(redhatDir, 'anonymousId');
+    return path.join(redhatDir, "anonymousId");
   }
 
-  export function readFile(filePath: string): string|undefined {
+  export function readFile(filePath: string): string | undefined {
     let content: string | undefined;
     if (fs.existsSync(filePath)) {
-      content = fs.readFileSync(filePath, { encoding: 'utf8' });
+      content = fs.readFileSync(filePath, { encoding: "utf8" });
       if (content) {
         content = content.trim();
       }
@@ -48,12 +50,12 @@ export namespace UUID {
     return content;
   }
 
-  export function writeFile(filePath: string, content: string){
+  export function writeFile(filePath: string, content: string) {
     const parentDir = path.dirname(filePath);
     if (!fs.existsSync(parentDir)) {
       fs.mkdirSync(parentDir, { recursive: true });
     }
-    fs.writeFileSync(filePath, content, { encoding: 'utf8' });
+    fs.writeFileSync(filePath, content, { encoding: "utf8" });
   }
 
   export function generateUUID(source: string): string {

--- a/src/vscode/constants.ts
+++ b/src/vscode/constants.ts
@@ -2,12 +2,12 @@
   OPT_IN_STATUS === "true" if user responded on the notification pop-up
   and undefined if the user has not responded or closed the notification pop-up    
 */
-export const OPT_IN_STATUS_KEY = 'redhat.telemetry.optInRequested';
+export const OPT_IN_STATUS_KEY = "redhat.telemetry.optInRequested";
 export const PRIVACY_STATEMENT_URL: string =
-  'https://developers.redhat.com/article/tool-data-collection';
+  "https://developers.redhat.com/article/tool-data-collection";
 export const OPT_OUT_INSTRUCTIONS_URL: string =
-  'https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting';
-export const CONFIG_KEY = 'redhat.telemetry';
+  "https://github.com/redhat-developer/vscode-redhat-telemetry#how-to-disable-telemetry-reporting";
+export const CONFIG_KEY = "redhat.telemetry";
 
-export const DEFAULT_SEGMENT_KEY = 'MXM7iv13sVaCGqOhnQEGLZxhfy6hecYh';
-export const DEFAULT_SEGMENT_DEBUG_KEY ='eKBn0xqKQcQJVhUOW0vdQtNQiK791OLa';
+export const DEFAULT_SEGMENT_KEY = "MXM7iv13sVaCGqOhnQEGLZxhfy6hecYh";
+export const DEFAULT_SEGMENT_DEBUG_KEY = "eKBn0xqKQcQJVhUOW0vdQtNQiK791OLa";

--- a/src/vscode/settings.ts
+++ b/src/vscode/settings.ts
@@ -1,16 +1,20 @@
-import { env, workspace, WorkspaceConfiguration } from 'vscode';
-import { TelemetrySettings } from '../interfaces/settings';
-import { CONFIG_KEY } from './constants';
+import { env, workspace, WorkspaceConfiguration } from "vscode";
+import { TelemetrySettings } from "../interfaces/settings";
+import { CONFIG_KEY } from "./constants";
 
 export class VSCodeSettings implements TelemetrySettings {
   isTelemetryEnabled(): boolean {
-    return this.getTelemetryLevel() !== 'off' && getTelemetryConfiguration().get<boolean>('enabled', false);
+    return (
+      this.getTelemetryLevel() !== "off" &&
+      getTelemetryConfiguration().get<boolean>("enabled", false)
+    );
   }
 
   getTelemetryLevel(): string {
     //Respecting old vscode telemetry settings https://github.com/microsoft/vscode/blob/f09c4124a229b4149984e1c2da46f35b873d23fa/src/vs/platform/telemetry/common/telemetryUtils.ts#L131
-    if (workspace.getConfiguration().get("telemetry.enableTelemetry") == false
-      || workspace.getConfiguration().get("telemetry.enableCrashReporter") == false
+    if (
+      workspace.getConfiguration().get("telemetry.enableTelemetry") == false ||
+      workspace.getConfiguration().get("telemetry.enableCrashReporter") == false
     ) {
       return "off";
     }
@@ -18,14 +22,13 @@ export class VSCodeSettings implements TelemetrySettings {
   }
 
   isTelemetryConfigured(): boolean {
-    return isPreferenceOverridden(CONFIG_KEY + '.enabled');
+    return isPreferenceOverridden(CONFIG_KEY + ".enabled");
   }
 
   updateTelemetryEnabledConfig(value: boolean): Thenable<void> {
-    return getTelemetryConfiguration().update('enabled', value, true);
+    return getTelemetryConfiguration().update("enabled", value, true);
   }
 }
-
 
 export function getTelemetryConfiguration(): WorkspaceConfiguration {
   return workspace.getConfiguration(CONFIG_KEY);
@@ -48,7 +51,10 @@ export function didUserDisableTelemetry(): boolean {
     return false;
   }
   //Telemetry is not enabled, but it might not be the user's choice.
-  //i.e. could be the App's default setting (VS Codium), or  
-  //then the user only asked for reporting errors/crashes, in which case we can do the same. 
-  return isPreferenceOverridden("telemetry.telemetryLevel") && workspace.getConfiguration().get("telemetry.telemetryLevel") === "off";
+  //i.e. could be the App's default setting (VS Codium), or
+  //then the user only asked for reporting errors/crashes, in which case we can do the same.
+  return (
+    isPreferenceOverridden("telemetry.telemetryLevel") &&
+    workspace.getConfiguration().get("telemetry.telemetryLevel") === "off"
+  );
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,3 @@
-import {
-    getRedHatService,
-    TelemetryService,
-  } from "../lib";
+import { getRedHatService, TelemetryService } from "../lib";
 
 console.log("Hello World");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "lib": [
-      "es6"
-    ],
+    "lib": ["es6"],
     "allowJs": true,
     "outDir": "./lib",
     "strict": true,
@@ -16,7 +14,5 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,30 +1,28 @@
-import * as path from 'path';
-import * as webpack from 'webpack';
-const WarningsToErrorsPlugin = require('warnings-to-errors-webpack-plugin');
+import * as path from "path";
+import * as webpack from "webpack";
+const WarningsToErrorsPlugin = require("warnings-to-errors-webpack-plugin");
 
 // in case you run into any typescript error when configuring `devServer`
 // import 'webpack-dev-server';
 
 const config: webpack.Configuration = {
-  mode: 'production',
-  entry: './test/index.ts',
+  mode: "production",
+  entry: "./test/index.ts",
   externals: {
-    "vscode": "commonjs vscode",
+    vscode: "commonjs vscode",
   },
   target: "node", // vscode extensions run in a Node.js-context
   node: {
     __dirname: false, // leave the __dirname-behavior intact
   },
   output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'foo.bundle.js',
+    path: path.resolve(__dirname, "dist"),
+    filename: "foo.bundle.js",
   },
-  plugins: [
-    new WarningsToErrorsPlugin(),
-  ],
+  plugins: [new WarningsToErrorsPlugin()],
   stats: {
     errorDetails: true,
-  }
+  },
 };
 
 export default config;


### PR DESCRIPTION
- Uses default prettier settings
- Include vscode settings to suggest prettier extension and configure it to reformat on save (it does not force the contributor to install it but it can help if he does)
- Update GHA to run linting after install and before build using "npm run lint".
- Enabling pre-commit.ci github app is not required but when enabled that app can auto-fix incoming pull requests, something that our own "npm run lint" cannot do.
