### PR TITLE
Prevent initialisation errors on Linux

### DIFF
--- a/src/webworker/platform.ts
+++ b/src/webworker/platform.ts
@@ -6,14 +6,6 @@ import env from '../common/envVar';
 import UAParser from 'ua-parser-js';
 
 let userAgentInfo : UAParser.IResult;
-export const PLATFORM = getPlatform();
-export const DISTRO = getDistribution();
-export const PLATFORM_VERSION = getUAInfo().os.version;
-export const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
-export const LOCALE = navigator.language.replace('_', '-');
-export const COUNTRY = getCountry(TIMEZONE);
-export const UI_KIND = getUIKind();
-export const USERNAME = getUsername();
 
 function getUAInfo() {
     if (userAgentInfo) {
@@ -104,3 +96,11 @@ function getUsername(): string | undefined {
     return username;
 }
 
+export const PLATFORM = getPlatform();
+export const DISTRO = getDistribution();
+export const PLATFORM_VERSION = getUAInfo().os.version;
+export const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+export const LOCALE = navigator.language.replace('_', '-');
+export const COUNTRY = getCountry(TIMEZONE);
+export const UI_KIND = getUIKind();
+export const USERNAME = getUsername();


### PR DESCRIPTION
The function 'getPlatform' is used before its definition. At that point, the global variable 'linuxes' is not yet initialised, resulting in errors like:

![image](https://github.com/redhat-developer/vscode-redhat-telemetry/assets/1756811/21e46bc3-eb79-4473-922d-baf7cc9732a7)

By moving all exports to the bottom, this problem should be fixed.

This is the cause of https://github.com/redhat-developer/vscode-yaml/issues/929.