### PR TITLE
Only include 30% of all 'textCompletion' events from 'redhat.java'.

### DIFF
--- a/src/config/telemetry-config.json
+++ b/src/config/telemetry-config.json
@@ -7,5 +7,14 @@
                 "name" : "*"
             }
         ]
+    },
+    "redhat.java": {
+        "enabled": "all",
+        "includes": [
+            {
+                "name": "textCompletion",
+                "ratio": "0.3"
+            }
+        ]
     }
 }


### PR DESCRIPTION
https://github.com/redhat-developer/vscode-java/blob/8fa2464e16028b248fd89efc14622aeab251e890/src/standardLanguageClient.ts#L837

@fbricon , let me know if the logic makes sense. I'm assuming it is merged with the `*` configuration to restrict the `textCompletion` event to just 1%. (as opposed to having to write an exclusion for 99%)

- This should not be merged yet. Ideally, we can merge a few days before the `redhat.java` release.