### PR TITLE
Only include 0.3% of all 'textCompletion' events from 'redhat.java'.

### DIFF
--- a/src/config/telemetry-config.json
+++ b/src/config/telemetry-config.json
@@ -13,7 +13,7 @@
         "excludes": [
             {
                 "name": "textCompletion",
-                "ratio": "0.7"
+                "ratio": "0.997"
             }
         ]
     }


### PR DESCRIPTION
- Exclude 99.7% of all 'textCompletion' events

CC: @fbricon 