### PR TITLE
Ratio of "0" should completely disable telemetry

### DIFF
--- a/src/common/impl/configuration.ts
+++ b/src/common/impl/configuration.ts
@@ -36,14 +36,13 @@ export class Configuration {
             return false;
         }
 
-
         const currUserRatioValue = numValue(event.userId);
         const configuredRatio = getRatio(this.json?.ratio);
-        if (configuredRatio < currUserRatioValue) {
+        if (configuredRatio === 0 || configuredRatio < currUserRatioValue) {
             return false;
         }
 
-        const isIncluded = this.isIncluded(event, currUserRatioValue) 
+        const isIncluded = this.isIncluded(event, currUserRatioValue)
                         && !this.isExcluded(event, currUserRatioValue)
         return isIncluded;
     }
@@ -93,7 +92,7 @@ export class Configuration {
         }
         return [];
     }
-    
+
     isEventMatching(event: AnalyticsEvent, patterns:EventPattern[], currUserRatioValue: number, including: boolean):boolean {
         if (!patterns || !patterns.length) {
             return false;
@@ -114,7 +113,7 @@ export class Configuration {
                     const configuredEventRatio = getRatio(evtPtn?.ratio);
                     if (including) {
                         return currUserRatioValue <= configuredEventRatio;
-                    } 
+                    }
                     // excluding 90% of user means keeping 10%
                     // so user ratio value of 0.11 should be excluded (i.e match) when excluded event ratio = 0.9
                     return currUserRatioValue > 1 - configuredEventRatio;

--- a/src/tests/services/configuration.test.ts
+++ b/src/tests/services/configuration.test.ts
@@ -64,6 +64,10 @@ suite('Test configurations', () => {
         ]
     };
 
+    const fullyRatioedEvent = {
+        "ratio": "0"
+    }
+
     test('Should allow all events****', async () => {
         const config = new Configuration(all);
         let event = { event: "something", userId: "abcd"} as AnalyticsEvent;
@@ -226,5 +230,14 @@ suite('Test configurations', () => {
             event: "verbose-event",
         } as AnalyticsEvent;
         assert.ok(config.canSend(event) === false, `${event.event} should not be sent`);
+    });
+
+    test('Should exclude 100.0% of events', async () => {
+        const config = new Configuration(fullyRatioedEvent);
+        let event = {
+            userId: "f2cec861-8a0e-46cf-b385-08c7676e6e7e", // works out to a hash of ###0000, which means a ratio of 0
+            event: "not-wanted-event"
+            } as AnalyticsEvent;
+        assert.ok(config.canSend(event) === false, `${event.event} shouldn't be sent`);
     });
 });


### PR DESCRIPTION
Currently, it allows events where the hash of the user's ID is a number that ends with `0000`.

Signed-off-by: David Thompson <davthomp@redhat.com>
