### PR TITLE
fix: remove query param from opt-out link to fix anchor navigation

### DIFF
--- a/src/common/vscode/redhatServiceInitializer.ts
+++ b/src/common/vscode/redhatServiceInitializer.ts
@@ -114,7 +114,7 @@ export abstract class AbstractRedHatServiceProvider {
 
     const message: string = `Help Red Hat improve its extensions by allowing them to collect usage data. 
       Read our [privacy statement](${PRIVACY_STATEMENT_URL}?from=${this.extensionId!}) 
-    and learn how to [opt out](${OPT_OUT_INSTRUCTIONS_URL}?from=${this.extensionId!}).`;
+    and learn how to [opt out](${OPT_OUT_INSTRUCTIONS_URL}).`;
 
     const retryOptin = setTimeout(this.openTelemetryOptInDialogIfNeeded, RETRY_OPTIN_DELAY_IN_MS);
     let selection: string | undefined;


### PR DESCRIPTION
The opt-out URL points to a GitHub anchor
(#how-to-disable-telemetry-reporting). Appending ?from=extensionId broke anchor resolution, making the link land on a 404-like page instead of scrolling to the correct section.

Fixes #172