### PR TITLE
ci: switch to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
     - uses: actions/checkout@v4
 
       # Set up Node
-    - name: Use Node 20
+    - name: Use Node 22
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
 
       # Run install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,16 +7,15 @@ on:
       - '*'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: write  # Required for creating releases
+  id-token: write  # Required for npm trusted publishing (OIDC)
+
 jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    permissions:
-      contents: write  # Required for creating releases
+    runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -25,11 +24,14 @@ jobs:
         fetch-depth: 0  # Fetch full history for changelog generation
 
       # Set up Node
-    - name: Use Node 20
+    - name: Use Node 22
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
+
+    - name: Use npm 12
+      run: npm install npm@^12 -g
 
       # Run install dependencies
     - name: Install dependencies
@@ -79,8 +81,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Publish to npm
+      # Publish to npm using trusted publishing (OIDC)
     - name: Publish to npm
       run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
         "@types/getos": "^3.0.1",
-        "@types/node": "^20.14.8",
+        "@types/node": "^22.0.0",
         "@types/object-hash": "^3.0.2",
         "@types/picomatch": "^4.0.0",
         "@types/ua-parser-js": "^0.7.36",
@@ -34,6 +34,9 @@
         "husky": "^9.1.7",
         "typescript": "^5.6.2",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22.14.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1489,13 +1492,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/object-hash": {
@@ -3346,10 +3349,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.1",
@@ -4507,12 +4511,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/object-hash": {
@@ -5607,9 +5611,9 @@
       }
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.11.0",
   "description": "Provides Telemetry APIs for Red Hat applications",
   "main": "lib/index.js",
+  "engines": {
+    "node": ">=22.14.0"
+  },
   "types": "lib",
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('lib',{recursive:true,force:true})\"",
@@ -41,7 +44,7 @@
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
     "@types/getos": "^3.0.1",
-    "@types/node": "^20.14.8",
+    "@types/node": "^22.0.0",
     "@types/object-hash": "^3.0.2",
     "@types/picomatch": "^4.0.0",
     "@types/ua-parser-js": "^0.7.36",


### PR DESCRIPTION
Followed instructions from https://docs.npmjs.com/trusted-publishers

- Add id-token: write permission for OIDC-based npm auth
- Remove NODE_AUTH_TOKEN secret from publish step
- Install npm@^12 in release workflow (trusted publishing requires >= 11.5.1)
- Bump Node from 20 to 22 in CI and release workflows
- Add engines.node >= 22.14.0 to package.json
- Update @types/node to ^22.0.0

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
